### PR TITLE
Finish the localization of the application

### DIFF
--- a/src/lang/bg.lang.php
+++ b/src/lang/bg.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'Български',
+	'locale' => 'bg_BG',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Инсталация',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Go back',
 		
 		'date_time_format' => 'd.m.Y H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
 	),
 	'menu' => array(
 		'config' => 'Настройки',
@@ -97,6 +111,8 @@ $sm_lang = array(
 		'domain' => 'Хост',
 		'port' => 'Порт',
 		'type' => 'Тип',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Търсене на образец/схема',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => 'Последна проверка',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => 'Основни настройки',
 		'language' => 'Език',
-		'language_en' => 'English',
-		'language_bg' => 'Български',
-		'language_nl' => 'Dutch',
-		'language_fr' => 'French',
-		'language_de' => 'German',
-		'language_kr' => 'Korean',
-		'language_br' => 'Portuguese - Brazilian',
 		'show_update' => 'Да проверява ли за нова версия всяка седмица?',
 		'email_status' => 'Да се изпращат ли имейли?',
 		'email_from_email' => 'Имейл, от който да се изпращат съобщенията',

--- a/src/lang/br.lang.php
+++ b/src/lang/br.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'Portugês - Brasil',
+	'locale' => 'pt_BR',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
     'system' => array(
         'title' => 'Server Monitor',
 		'install' => 'Install',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Go back',
 		
 		'date_time_format' => 'd/m/Y H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
     ),
 	'menu' => array(
 		'config' => 'Configuração',
@@ -97,6 +111,8 @@ $sm_lang = array(
         'domain' => 'Domínio/IP',
         'port' => 'Porta',
         'type' => 'Tipo',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Search string/pattern',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
         'last_check' => 'Última verificação',
@@ -122,13 +138,6 @@ $sm_lang = array(
     'config' => array(
         'general' => 'Geral',
         'language' => 'Idioma',
-        'language_en' => 'Inglês',
-		'language_bg' => 'Bulgarian',
-        'language_nl' => 'Holandês',
-        'language_fr' => 'Francês',
-        'language_de' => 'Alemão',
-        'language_kr' => 'Koreano',
-        'language_br' => 'Portugês - Brasil',
         'show_update' => 'verificar atualizações semanalmente?',
         'email_status' => 'Habilitar envio de email?',
         'email_from_email' => 'Endereço do envio de email',

--- a/src/lang/de.lang.php
+++ b/src/lang/de.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'Dutch',
+	'locale' => 'de_DE',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Install',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Go back',
 		
 		'date_time_format' => 'd.m.Y H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
 	),
 	'menu' => array(
 		'config' => 'Einstellungen',
@@ -97,6 +111,8 @@ $sm_lang = array(
 		'domain' => 'Domain/IP',
 		'port' => 'Port',
 		'type' => 'Type',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Search string/pattern',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => 'Letzter Check',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => 'General',
 		'language' => 'Sprache',
-		'language_en' => 'English',
-		'language_bg' => 'Bulgarian',
-		'language_nl' => 'Dutch',
-		'language_fr' => 'French',
-		'language_de' => 'German',
-		'language_kr' => 'Korean',
-		'language_br' => 'Portuguese - Brazilian',
 		'show_update' => 'Updats w&ouml;chentlich pr&uuml;fen?',
 		'email_status' => 'Email senden erlauben?',
 		'email_from_email' => 'Email from address',

--- a/src/lang/en.lang.php
+++ b/src/lang/en.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'English',
+	'locale' => 'en_US',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Install',
@@ -45,7 +47,19 @@ $sm_lang = array(
 		'back_to_top' => 'Back to top',
 		'go_back' => 'Go back',
 		
-		'date_time_format' => 'Y-m-d H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		'date_time_format' => 'Y-m-d g:i:sa',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
 	),
 	'menu' => array(
 		'config' => 'Config',
@@ -97,6 +111,8 @@ $sm_lang = array(
 		'domain' => 'Domain/IP',
 		'port' => 'Port',
 		'type' => 'Type',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Search string/pattern',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => 'Last check',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => 'General',
 		'language' => 'Language',
-		'language_en' => 'English',
-		'language_bg' => 'Bulgarian',
-		'language_nl' => 'Dutch',
-		'language_fr' => 'French',
-		'language_de' => 'German',
-		'language_kr' => 'Korean',
-		'language_br' => 'Portuguese - Brazilian',
 		'show_update' => 'Check for new updates weekly?',
 		'email_status' => 'Allow sending email?',
 		'email_from_email' => 'Email from address',

--- a/src/lang/fr.lang.php
+++ b/src/lang/fr.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'Français',
+	'locale' => 'fr_FR',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Installer',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Retour',
 		
 		'date_time_format' => 'd/m/Y H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+
+		'short_day_format' => 'Le %e %B',			// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => 'Le %e %B %Y',
+		'yesterday_format' => 'Hier à %kh%M',
+		'other_day_format' => '%A à %kh%M',
+		'never' => 'Jamais',
+		'hours_ago' => 'Il y a %d heures',
+		'an_hour_ago' => 'Il y a une heure',
+		'minutes_ago' => 'Il y a %d minutes',
+		'a_minute_ago' => 'Il y a une minute',
+		'seconds_ago' => 'Il y a %d secondes',
+		'a_second_ago' => 'Il y a une seconde',
 	),
 	'menu' => array(
 		'config' => 'Configuration',
@@ -67,7 +81,7 @@ $sm_lang = array(
 		'level' => 'Niveau',
 		'level_10' => 'Administrateur',
 		'level_20' => 'Utilisateur',
-		'level_description' => '<b>Administrators</b> have full access: they can manage servers, users and edit the global configuration.<br/><b>Users</b> can only view and run the updater for the servers that have been assigned to them.',
+		'level_description' => 'Les <b>Administrateurs</b> ont un accès total. Ils peuvent gérer les serveurs, les utilisateurs et éditer la configuration globale.<br/>Les <b>Utilisateurs</b> ne peuvent que voir et mettre à jour les serveurs qui leur ont été assignés.',
 		'mobile' => 'Numéro de téléphone',
 		'email' => 'Email',
 		'updated' => 'Utilisateur mis à jour.',
@@ -97,8 +111,10 @@ $sm_lang = array(
 		'domain' => 'Domaine/IP',
 		'port' => 'Port',
 		'type' => 'Type',
+		'type_website' => 'Site Web',
+		'type_service' => 'Service',
 		'pattern' => 'Rechercher un texte/motif',
-		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
+		'pattern_description' => 'Si ce texte n\'est par retrouvé sur le site web, le serveur est marqué hors-service. Les expressions réguliaires sont autorisées.',
 		'last_check' => 'Dernière vérification',
 		'last_online' => 'Dernière fois OK',
 		'monitoring' => 'Serveillé',
@@ -111,8 +127,8 @@ $sm_lang = array(
 		'week' => 'Semaine',
 		'day' => 'Jour',
 		'hour' => 'Heure',
-		'warning_threshold' => 'Warning threshold',
-		'warning_threshold_description' => 'Number of failed checks required before it is marked offline.',
+		'warning_threshold' => 'Seuil d\'alerte',
+		'warning_threshold_description' => 'Nombre d\'échecs de connexion avant que le serveur soit marqué hors-service.',
 
 		// Charts date format according jqPlot date format  http://www.jqplot.com/docs/files/plugins/jqplot-dateAxisRenderer-js.html
 		'chart_long_date_format' => '%d/%m/%Y %H:%M:%S',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => 'Général',
 		'language' => 'Langue',
-		'language_en' => 'English',
-		'language_bg' => 'Bulgarian',
-		'language_nl' => 'Dutch',
-		'language_fr' => 'Français',
-		'language_de' => 'German',
-		'language_kr' => 'Korean',
-		'language_br' => 'Portuguese - Brazilian',
 		'show_update' => 'Vérifier les nouvelles mise à jour chaque semaines',
 		'email_status' => 'Autoriser l\'envoi de mail',
 		'email_from_email' => 'Adresse de l\'expéditeur',
@@ -180,7 +189,7 @@ $sm_lang = array(
 	'notifications' => array(
 		'off_sms' => 'Le Serveur \'%LABEL%\' est HORS SERVICE: IP=%IP%, Port=%PORT%. Erreur=%ERROR%',
 		'off_email_subject' => 'IMPORTANT: Le Serveur \'%LABEL%\' est HORS SERVICE',
-		'off_email_body' => "Impossible de v&eacute;rifier le serveur suivant:<br/><br/>Serveur: %LABEL%<br/>IP: %IP%<br/>Port: %PORT%<br/>Erreur: %ERROR%<br/>Date: %DATE%",
+		'off_email_body' => "Impossible de se connecter au serveur suivant:<br/><br/>Serveur: %LABEL%<br/>IP: %IP%<br/>Port: %PORT%<br/>Erreur: %ERROR%<br/>Date: %DATE%",
 		'on_sms' => 'Le Serveur \'%LABEL%\' est OK: IP=%IP%, Port=%PORT%',
 		'on_email_subject' => 'IMPORTANT: Le Serveur \'%LABEL%\' est OK',
 		'on_email_body' => "Le Serveur '%LABEL%' est de nouveau OK:<br/><br/>Serveur: %LABEL%<br/>IP: %IP%<br/>Port: %PORT%<br/>Date: %DATE%",

--- a/src/lang/kr.lang.php
+++ b/src/lang/kr.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => '한국',
+	'locale' => 'ko_KR',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Install',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Go back',
 		
 		'date_time_format' => 'Y-m-d H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
 	),
 	'menu' => array(
 		'config' => '설정',
@@ -97,6 +111,8 @@ $sm_lang = array(
 		'domain' => 'Domain/IP',
 		'port' => 'Port',
 		'type' => 'Type',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Search string/regex',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => '최근체크',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => '일반',
 		'language' => '언어',
-		'language_en' => '미국',
-		'language_bg' => 'Bulgarian',
-		'language_nl' => '네덜란드',
-		'language_fr' => '프랑스',
-		'language_de' => '독일',
-		'language_kr' => '한국',
-		'language_br' => 'Portuguese - Brazilian',
 		'show_update' => '매주 업데이트를 확인하시겠습니까?',
 		'email_status' => '메일전송 허용',
 		'email_from_email' => 'Email 주소',

--- a/src/lang/nl.lang.php
+++ b/src/lang/nl.lang.php
@@ -26,6 +26,8 @@
  **/
 
 $sm_lang = array(
+	'name' => 'Nederlands',
+	'locale' => 'nl_NL',					// Language code (ISO 639-1) + Contry code (ISO_3166-1)
 	'system' => array(
 		'title' => 'Server Monitor',
 		'install' => 'Install',
@@ -46,6 +48,18 @@ $sm_lang = array(
 		'go_back' => 'Terug',
 		
 		'date_time_format' => 'd-m-Y H:i:s',		// date/time format according the date php function format parameter http://php.net/manual/function.date.php
+		
+		'short_day_format' => '%B %e',				// date/time format according the strftime php function format parameter http://php.net/manual/function.strftime.php
+		'long_day_format' => '%B %e, %Y',
+		'yesterday_format' => 'Yesterday at %l:%Ma',
+		'other_day_format' => '%A at g:ia',
+		'never' => 'Never',
+		'hours_ago' => '%d hours ago',
+		'an_hour_ago' => 'about an hour ago',
+		'minutes_ago' => '%d minutes ago',
+		'a_minute_ago' => 'about a minute ago',
+		'seconds_ago' => '%d seconds ago',
+		'a_second_ago' => 'a second ago',
 	),
 	'menu' => array(
 		'config' => 'Config',
@@ -97,6 +111,8 @@ $sm_lang = array(
 		'domain' => 'Domein/IP',
 		'port' => 'Poort',
 		'type' => 'Type',
+		'type_website' => 'Website',
+		'type_service' => 'Service',
 		'pattern' => 'Zoek voor tekst/regex',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => 'Laatst gecontroleerd',
@@ -122,13 +138,6 @@ $sm_lang = array(
 	'config' => array(
 		'general' => 'Algemeen',
 		'language' => 'Taal',
-		'language_en' => 'Engels',
-		'language_bg' => 'Bulgarian',
-		'language_nl' => 'Nederlands',
-		'language_fr' => 'Frans',
-		'language_de' => 'Duits',
-		'language_kr' => 'Koreaans',
-		'language_br' => 'Portugees - Braziliaans',
 		'show_update' => 'Check for new updates weekly?',
 		'email_status' => 'Sta email berichten toe?',
 		'email_from_email' => 'Email van adres',

--- a/src/psm/Module/Config/Controller/ConfigController.class.php
+++ b/src/psm/Module/Config/Controller/ConfigController.class.php
@@ -92,13 +92,7 @@ class ConfigController extends AbstractController {
 		// generate language array
 		$lang_keys = psm_get_langs();
 		$languages = array();
-		foreach($lang_keys as $key) {
-			$label = psm_get_lang('config', 'language_' . $key);
-			// if we don't have a proper label, just show the key..
-			// better something than nothing huh
-			if($label == null) {
-				$label = $key;
-			}
+		foreach($lang_keys as $key => $label) {
 			$languages[] = array(
 				'value' => $key,
 				'label' => $label,

--- a/src/psm/Module/Server/Controller/ServerController.class.php
+++ b/src/psm/Module/Server/Controller/ServerController.class.php
@@ -81,6 +81,9 @@ class ServerController extends AbstractServerController {
 			$servers[$x]['rtime'] = round((float) $servers[$x]['rtime'], 4);
 			$servers[$x]['last_online']  = psm_date($servers[$x]['last_online']);
 			$servers[$x]['last_check']  = psm_date($servers[$x]['last_check']);
+			$servers[$x]['active'] = psm_get_lang('system', $servers[$x]['active']);
+			$servers[$x]['email'] = psm_get_lang('system', $servers[$x]['email']);
+			$servers[$x]['sms'] = psm_get_lang('system', $servers[$x]['sms']);
 
 			if($servers[$x]['type'] == 'website') {
 				// add link to label
@@ -90,6 +93,8 @@ class ServerController extends AbstractServerController {
 			if($servers[$x]['status'] == 'on' && $servers[$x]['warning_threshold_counter'] > 0) {
 				$servers[$x]['status'] = 'warning';
 			}
+			
+			$servers[$x]['type'] = psm_get_lang('servers', 'type_' . $servers[$x]['type']);
 		}
 		// add servers to template
 		$this->tpl->addTemplateDataRepeat($this->getTemplateId(), 'servers', $servers);
@@ -223,6 +228,9 @@ class ServerController extends AbstractServerController {
 				'label_label' => psm_get_lang('servers', 'label'),
 				'label_domain' => psm_get_lang('servers', 'domain'),
 				'label_port' => psm_get_lang('servers', 'port'),
+				'label_type' => psm_get_lang('servers', 'type'),
+				'label_website' => psm_get_lang('servers', 'type_website'),
+				'label_service' => psm_get_lang('servers', 'type_service'),
 				'label_type' => psm_get_lang('servers', 'type'),
 				'label_pattern' => psm_get_lang('servers', 'pattern'),
 				'label_pattern_description' => psm_get_lang('servers', 'pattern_description'),

--- a/src/templates/servers.tpl.html
+++ b/src/templates/servers.tpl.html
@@ -84,8 +84,8 @@
                 <label class="control-label" for="type">{label_type}</label>
                 <div class="controls">
                     <select id="type" name="type">
-                        <option value="service" {edit_type_selected_service}>Service</option>
-                        <option value="website" {edit_type_selected_website}>Website</option>
+                        <option value="service" {edit_type_selected_service}>{label_service}</option>
+                        <option value="website" {edit_type_selected_website}>{label_website}</option>
                      </select>
                 </div>
             </div>


### PR DESCRIPTION
As thierryve didn't answer, I finished the localization of phpServerMon.
But you need some explanations.
1) Some date translation needs to be localized and the function date() cannot do it. So I used the function strftime. But this function needs the php locale to be set by setlocale(). The parameter is a combination of  language code and a country code. The lang file name code is not good for that, so I add this code in the lang file itself.
2) the language file name is not correct and should use the same code. "br.lang" does not make sense because Brazil is a country, not a language. for this reason, the file should name pt_BR.lang.php, 
Portuguese from Brazil. It is not really a problem yet, but it could become so if we wanted to differentiate the American English  (en_US) from the British English (en_GB).
3) It's a shame that the language name should be translate in each language file, and it's not logical. Each language names in the configuration should be written in is own language. I made the changes for this. Now each language file are totally independent. The language name is read directly from the file itself.
4) If the current language file is not found, the English language file is used.
