### PR TITLE
'Status' translation

### DIFF
--- a/src/lang/bg_BG.lang.php
+++ b/src/lang/bg_BG.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Сървър',
+		'status' => 'Статус',
 		'label' => 'Име',
 		'domain' => 'Хост',
 		'port' => 'Порт',

--- a/src/lang/de_DE.lang.php
+++ b/src/lang/de_DE.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Server',
+		'status' => 'Status',
 		'label' => 'Beschriftung',
 		'domain' => 'Domain/IP',
 		'port' => 'Port',

--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Server',
+		'status' => 'Status',
 		'label' => 'Label',
 		'domain' => 'Domain/IP',
 		'port' => 'Port',

--- a/src/lang/es_ES.lang.php
+++ b/src/lang/es_ES.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Servidores',
+		'status' => 'Status',
 		'label' => 'Titulo',
 		'domain' => 'Domain/IP',
 		'port' => 'Port',

--- a/src/lang/fr_FR.lang.php
+++ b/src/lang/fr_FR.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Serveur',
+		'status' => 'État',
 		'label' => 'Description',
 		'domain' => 'Domaine/IP',
 		'port' => 'Port',

--- a/src/lang/it_IT.lang.php
+++ b/src/lang/it_IT.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Server',
+		'status' => 'Status',
 		'label' => 'Nome',
 		'domain' => 'Dominio/IP',
 		'port' => 'Porta',

--- a/src/lang/ko_KR.lang.php
+++ b/src/lang/ko_KR.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => '서버',
+		'status' => 'Status',
 		'label' => 'Label',
 		'domain' => 'Domain/IP',
 		'port' => 'Port',

--- a/src/lang/nl_NL.lang.php
+++ b/src/lang/nl_NL.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => 'Server',
+		'status' => 'Status',
 		'label' => 'Label',
 		'domain' => 'Domein/IP',
 		'port' => 'Poort',

--- a/src/lang/pt_BR.lang.php
+++ b/src/lang/pt_BR.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
     ),
     'servers' => array(
         'server' => 'Servidor',
+		'status' => 'Status',
         'label' => 'Etiqueta',
         'domain' => 'Domínio/IP',
         'port' => 'Porta',

--- a/src/lang/zh_CN.lang.php
+++ b/src/lang/zh_CN.lang.php
@@ -108,6 +108,7 @@ $sm_lang = array(
 	),
 	'servers' => array(
 		'server' => '服务器',
+		'status' => '状态',
 		'label' => '标签',
 		'domain' => '域名/IP',
 		'port' => '端口',

--- a/src/psm/Module/Server/Controller/ServerController.class.php
+++ b/src/psm/Module/Server/Controller/ServerController.class.php
@@ -311,7 +311,7 @@ class ServerController extends AbstractServerController {
 			array(
 				'subtitle' => psm_get_lang('menu', 'server'),
 				'label_label' => psm_get_lang('servers', 'label'),
-				'label_status' => psm_get_lang('menu', 'server_status'),
+				'label_status' => psm_get_lang('servers', 'status'),
 				'label_domain' => psm_get_lang('servers', 'domain'),
 				'label_port' => psm_get_lang('servers', 'port'),
 				'label_type' => psm_get_lang('servers', 'type'),


### PR DESCRIPTION
In French, the best translation for Status is 'État' (State in English). 'Statut' exists in French but not in this context.
The word is without s for a single server.
