### PR TITLE
Added simple support for SSL/TLS to SMTP.

### DIFF
--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -386,6 +386,11 @@ function psm_build_mail($from_name = null, $from_email = null) {
 		$phpmailer->IsSMTP();
 		$phpmailer->Host = psm_get_conf('email_smtp_host');
 		$phpmailer->Port = psm_get_conf('email_smtp_port');
+		if ($phpmailer->Port == 587) {
+			$phpmailer->SMTPSecure = 'tls';
+		} else if ($phpmailer->Port == 465) {
+			$phpmailer->SMTPSecure = 'ssl';
+		}
 
 		$smtp_user = psm_get_conf('email_smtp_username');
 		$smtp_pass = psm_get_conf('email_smtp_password');


### PR DESCRIPTION
This simple change enables the use of SSL when using port 465 and TLS when using port 587 in the SMTP functionality. This allows the use of GMail as the SMTP gateway.
A more robust solution would be to add UI configuration for the SMTPSecure option.
