### PR TITLE
Enable check for website with unverified SSL

### DIFF
--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -273,6 +273,8 @@ function psm_curl_get($href, $header = false, $body = true, $timeout = 10, $add_
 	curl_setopt($ch, CURLOPT_NOBODY, (!$body));
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
 	curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 	curl_setopt($ch, CURLOPT_ENCODING, '');


### PR DESCRIPTION
Enable Website status check when SSL certificate is not verified.

On master, the current behavior is that website is reported as down, since SSL is not verified, and connection is not allowed to be performed
