### PR TITLE
Updated the results template to allow links, with autoescape.

### DIFF
--- a/src/templates/default/module/install/results.tpl.html
+++ b/src/templates/default/module/install/results.tpl.html
@@ -3,7 +3,9 @@
 	{% for msg in messages %}
 	<div>
 		<p class="pull-left"><span class="label label-{{ msg.shortcode }}">{{ msg.shortcode }}</span></p>
+		{% autoescape false %}
 		<p class="offset1">{{ msg.message }}</p>
+		{% endautoescape %}
 	</div>
 	{% endfor %}
 {% endif %}


### PR DESCRIPTION
msg.message was just dumping an autoescaped link '<a href="http://www.php.net/manual/en/timezones.php" target="_blank">this page</a>' rather than a hyperlink.

If this is unsafe, the other option would be to just remove the a tag, and just have a basic url.
