### PR TITLE
Support freevoipdeal for sending SMS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ not yet released
 ----------------------------------
 
 * #161: Added Swedish translation.
+* #xxx: Added support for FreeVoipDeal SMS gateway <http://www.freevoipdeal.com>
 
 
 v3.1.1 (released November 6, 2014)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ not yet released
 ----------------------------------
 
 * #161: Added Swedish translation.
-* #xxx: Added support for FreeVoipDeal SMS gateway <http://www.freevoipdeal.com>
+* #164: Added support for FreeVoipDeal SMS gateway <http://www.freevoipdeal.com>
 
 
 v3.1.1 (released November 6, 2014)

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ The following SMS gateways are currently available:
 * SMSit - <http://www.smsit.dk/>
 * Spryng - <http://www.spryng.nl>
 * Textmarketer - <http://www.textmarketer.co.uk>
+* FreeVoipDeal - <http://www.freevoipdeal.com>
 
 Please note: for these gateways you will need an account with sufficient credits.
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -9,6 +9,10 @@ Credits
 
 The following people have contributed to the development of PHP Server Monitor:
 
+* Michiel van der Wulp - https://github.com/mvdw
+
+  * FreeVoipDeal SMS gateway
+
 * Pepijn Over - https://github.com/dopeh
 
   * Creator and project maintainer

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -55,6 +55,7 @@ The following SMS gateways are currently available:
 * SMSit - <http://www.smsit.dk/>
 * Spryng - <http://www.spryng.nl>
 * Textmarketer - <http://www.textmarketer.co.uk>
+* FreeVoipDeal - <http://www.freevoipdeal.com>
 
 Please note: for these gateways you will need an account with sufficient credits.
 

--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -466,6 +466,9 @@ function psm_build_sms() {
 		case 'smsglobal':
 			$sms = new \psm\Txtmsg\Smsglobal();
 			break;
+		case 'freevoipdeal':
+			$sms = new \psm\Txtmsg\FreeVoipDeal();
+			break;
 	}
 
 	// copy login information from the config file

--- a/src/lang/bg_BG.lang.php
+++ b/src/lang/bg_BG.lang.php
@@ -194,6 +194,7 @@ $sm_lang = array(
 		'sms_gateway_inetworx' => 'Inetworx',
 		'sms_gateway_clickatell' => 'Clickatell',
 		'sms_gateway_textmarketer' => 'Textmarketer',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_username' => 'Потребител',
 		'sms_gateway_password' => 'Парола',

--- a/src/lang/cs_CZ.lang.php
+++ b/src/lang/cs_CZ.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Uživatelské jméno brány',
 		'sms_gateway_password' => 'Heslo brány',
 		'sms_from' => 'Telefonní číslo odesilatele',

--- a/src/lang/da_DK.lang.php
+++ b/src/lang/da_DK.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway brugernavn/apikey',
 		'sms_gateway_password' => 'Gateway adgangskode',
 		'sms_from' => 'Afsenders navn.',

--- a/src/lang/de_DE.lang.php
+++ b/src/lang/de_DE.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway Benutzername',
 		'sms_gateway_password' => 'Gateway Passwort',
 		'sms_from' => 'SMS-Sendernummer',

--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway username',
 		'sms_gateway_password' => 'Gateway password',
 		'sms_from' => 'Sender\'s phone number',

--- a/src/lang/es_ES.lang.php
+++ b/src/lang/es_ES.lang.php
@@ -196,6 +196,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway username',
 		'sms_gateway_password' => 'Gateway password',
 		'sms_from' => 'Número origen del SMS',

--- a/src/lang/fr_FR.lang.php
+++ b/src/lang/fr_FR.lang.php
@@ -196,6 +196,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Nom utilisateur de la passerelle',
 		'sms_gateway_password' => 'Mot de passe de la passerelle',
 		'sms_from' => 'SMS de l\'expéditeur',

--- a/src/lang/it_IT.lang.php
+++ b/src/lang/it_IT.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Nome Utente Gateway',
 		'sms_gateway_password' => 'Password Gateway',
 		'sms_from' => 'Numero di telefono del mittente',

--- a/src/lang/ko_KR.lang.php
+++ b/src/lang/ko_KR.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
 		'sms_gateway_smsit' => 'Smsit',
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway username',
 		'sms_gateway_password' => 'Gateway password',
 		'sms_from' => 'Sender\'s phone number',

--- a/src/lang/nl_NL.lang.php
+++ b/src/lang/nl_NL.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway gebruikersnaam',
 		'sms_gateway_password' => 'Gateway wachtwoord',
 		'sms_from' => 'Telefoonnummer afzender',

--- a/src/lang/pl_PL.lang.php
+++ b/src/lang/pl_PL.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Login do bramki',
 		'sms_gateway_password' => 'Hasło do bramki',
 		'sms_from' => 'Numer nadawcy',

--- a/src/lang/pt_BR.lang.php
+++ b/src/lang/pt_BR.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
 		'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
         'sms_gateway_username' => 'Usuário do Gateway',
         'sms_gateway_password' => 'Senha do Gateway',
         'sms_from' => 'Número de telefone de envio',

--- a/src/lang/ru_RU.lang.php
+++ b/src/lang/ru_RU.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Пользователь',
 		'sms_gateway_password' => 'Пароль',
 		'sms_from' => 'Номер отправителя',

--- a/src/lang/sv_SE.lang.php
+++ b/src/lang/sv_SE.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'Gateway användarnamn',
 		'sms_gateway_password' => 'Gateway lösenord',
 		'sms_from' => 'Avsändarens telefonnummer',

--- a/src/lang/tr_TR.lang.php
+++ b/src/lang/tr_TR.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
         'sms_gateway_smsglobal' => 'SMSGlobal',
         'sms_gateway_smsit' => 'Smsit',
+        'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
         'sms_gateway_username' => 'Servis kullanıcı adı',
         'sms_gateway_password' => 'Servis şifresi',
         'sms_from' => 'Gönderen numarası',

--- a/src/lang/zh_CN.lang.php
+++ b/src/lang/zh_CN.lang.php
@@ -195,6 +195,7 @@ $sm_lang = array(
         'sms_gateway_textmarketer' => 'Textmarketer',
 		'sms_gateway_smsglobal' => 'SMSGlobal',
 		'sms_gateway_smsit' => 'Smsit',
+		'sms_gateway_freevoipdeal' => 'FreeVoipDeal',
 		'sms_gateway_username' => 'SMS网关用户名',
 		'sms_gateway_password' => 'SMS网关密码',
 		'sms_from' => '发信人电话号',

--- a/src/psm/Module/Config/Controller/ConfigController.class.php
+++ b/src/psm/Module/Config/Controller/ConfigController.class.php
@@ -313,6 +313,7 @@ class ConfigController extends AbstractController {
 			'label_sms_gateway_clickatell' => psm_get_lang('config', 'sms_gateway_clickatell'),
 			'label_sms_gateway_textmarketer' => psm_get_lang('config', 'sms_gateway_textmarketer'),
 			'label_sms_gateway_smsit' => psm_get_lang('config', 'sms_gateway_smsit'),
+			'label_sms_gateway_freevoipdeal' => psm_get_lang('config', 'sms_gateway_freevoipdeal'),
 			'label_sms_gateway_smsglobal' => psm_get_lang('config', 'sms_gateway_smsglobal'),
 			'label_sms_gateway_username' => psm_get_lang('config', 'sms_gateway_username'),
 			'label_sms_gateway_password' => psm_get_lang('config', 'sms_gateway_password'),

--- a/src/psm/Txtmsg/FreeVoipDeal.class.php
+++ b/src/psm/Txtmsg/FreeVoipDeal.class.php
@@ -46,7 +46,7 @@ class FreeVoipDeal extends Core {
 
 			$result = file_get_contents( $local_url . "?username=" . $this->username
 				. "&password=" . $this->password . "&from=" . $this->originator . "&to=" . $phone
-				. "&text=TEST-" . $local_data );
+				. "&text=" . $local_data );
 		}
 
 		return $result;

--- a/src/psm/Txtmsg/FreeVoipDeal.class.php
+++ b/src/psm/Txtmsg/FreeVoipDeal.class.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHP Server Monitor
+ * Monitor your servers and websites.
+ *
+ * This file is part of PHP Server Monitor.
+ * PHP Server Monitor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PHP Server Monitor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PHP Server Monitor.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package     phpservermon
+ * @author      Michiel van der Wulp <michiel@vanderwulp.be>
+ * @copyright   Copyright (c) 2014 Michiel van der Wulp
+ * @license     http://www.gnu.org/licenses/gpl.txt GNU GPL v3
+ * @version     Release: v3.1.0
+ * @link        http://www.phpservermonitor.org/
+ **/
+
+namespace psm\Txtmsg;
+
+class FreeVoipDeal extends Core {
+	// =========================================================================
+	// [ Fields ]
+	// =========================================================================
+	public $gateway = 1;
+	public $resultcode = null;
+	public $resultmessage = null;
+	public $success = false;
+	public $successcount = 0;
+
+	public function sendSMS($message) {
+
+		$local_url = "https://www.freevoipdeal.com/myaccount/sendsms.php";
+		$local_data = rawurlencode( $message );
+
+		foreach( $this->recipients as $phone ){
+
+			$result = file_get_contents( $local_url . "?username=" . $this->username
+				. "&password=" . $this->password . "&from=" . $this->originator . "&to=" . $phone
+				. "&text=TEST-" . $local_data );
+		}
+
+		return $result;
+	}
+}


### PR DESCRIPTION
Please add support for www.freevoipdeal.com for sending SMS. This is one of the Dellmont brands, of which there are many. I have no tie to this company, but I guess they are silently one of the biggest in the voip market. I have been using this company for years.

I tested this code - it works.
Using vagrant for development makes it so easy!

For the future, maybe the phpservermon could be extended to allow adding other SMS senders from the Dellmont family easily.