### PR TITLE
Ignore 401 Unauthorized and 403 Forbidden headers, site is still online.

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -198,7 +198,8 @@ class StatusUpdater {
 			$msg = $code_matches[2][0];
 
 			// All status codes starting with a 4 or higher mean trouble!
-			if(substr($code, 0, 1) >= '4') {
+			// Ignore 401 Unauthorized and 403 Forbidden, site is still online.
+			if(substr($code, 0, 1) >= '4' && $code != '401' && $code != '403') {
 				$this->error = $code . ' ' . $msg;
 				$result = false;
 			} else {


### PR DESCRIPTION
Fix for phpservermon displaying header 401 and 403 as offline.