### PR TITLE
If pattern is set up, you cannot catch server problems

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -191,7 +191,7 @@ class StatusUpdater {
 
 		if(empty($code_matches[0])) {
 			// somehow we dont have a proper response.
-			$this->error = 'no response from server';
+			$this->error = 'TIMEOUT ERROR: no response from server';
 			$result = false;
 		} else {
 			$code = $code_matches[1][0];
@@ -199,17 +199,19 @@ class StatusUpdater {
 
 			// All status codes starting with a 4 or higher mean trouble!
 			if(substr($code, 0, 1) >= '4') {
-				$this->error = $code . ' ' . $msg;
+				$this->error = "HTTP STATUS ERROR: ".$code . ' ' . $msg;
 				$result = false;
 			} else {
 				$result = true;
-			}
-		}
-		if($this->server['pattern'] != '') {
-			// Check to see if the pattern was found.
-			if(!preg_match("/{$this->server['pattern']}/i", $curl_result)) {
-				$this->error = 'Pattern not found.';
-				$result = false;
+				
+				//Okay, the HTTP status is good : 2xx or 3xx. Now we have to test the pattern if it's set up
+				if($this->server['pattern'] != '') {
+					// Check to see if the pattern was found.
+					if(!preg_match("/{$this->server['pattern']}/i", $curl_result)) {
+						$this->error = 'TEXT ERROR : Pattern not found.';
+						$result = false;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
The need : to have 3 differents error codes :

- Timeout
- Http status code
- pattern not found.

The error of status code or timebout where overwritten by pattern, if set up