### PR TITLE
Fix for issue #187 (Unable to connect to MySQL)

### DIFF
--- a/src/config/services.xml
+++ b/src/config/services.xml
@@ -18,9 +18,9 @@ xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/sc
 		<parameter key="path.templates">%path.src%templates</parameter>
 
 		<parameter key="db.host" type="constant">PSM_DB_HOST</parameter>
-		<parameter key="db.name" type="constant">PSM_DB_NAME</parameter>
 		<parameter key="db.user" type="constant">PSM_DB_USER</parameter>
 		<parameter key="db.pass" type="constant">PSM_DB_PASS</parameter>
+		<parameter key="db.name" type="constant">PSM_DB_NAME</parameter>
 	</parameters>
 
 	<services>
@@ -35,9 +35,9 @@ xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/sc
 		<!--SERVICES start-->
 		<service id="db" class="psm\Service\Database">
 			<argument>%db.host%</argument>
-			<argument>%db.name%</argument>
 			<argument>%db.user%</argument>
 			<argument>%db.pass%</argument>
+			<argument>%db.name%</argument>
 		</service>
 
 		<service id="event" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher">


### PR DESCRIPTION
On the current version, new installation throw an error Unable to connect to MySQL, due to the services.xml declaration doesn't meet the psm\Service\Database constructor