### PR TITLE
#367 fixed a csrf bug since 2014

### DIFF
--- a/src/psm/Module/Server/Controller/StatusController.php
+++ b/src/psm/Module/Server/Controller/StatusController.php
@@ -37,6 +37,7 @@ class StatusController extends AbstractServerController {
 	function __construct(Database $db, \Twig_Environment $twig) {
 		parent::__construct($db, $twig);
 
+		$this->setCSRFKey('status');
 		$this->setActions(array('index', 'saveLayout'), 'index');
 	}
 

--- a/src/templates/default/module/server/status/index.tpl.html
+++ b/src/templates/default/module/server/status/index.tpl.html
@@ -1,4 +1,5 @@
 <div class="tab-content">
+	<input type="hidden" name="saveLayout_csrf" value="{{ csrf_token(csrf_key|default('')) }}" />
 	<div id="flow-layout" class="tab-pane {{ block_layout_active }}">
 		<div class="entity-container">
 			{% for server in servers_offline %}

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -135,6 +135,7 @@ function psm_xhr(mod, params, method, on_complete, options) {
 function psm_saveLayout(layout) {
 	var params = {
 		action: 'saveLayout',
+		csrf: $("input[name=saveLayout_csrf]").val(),
 		layout: layout
 	};
 	psm_xhr('server_status', params, 'POST');


### PR DESCRIPTION
The status page has a csrf bug. status didn't set csrf key and the psm_saveLayout function didn't send CSRFKey.

When layout switch will send a POST AJAX quest, This will get a 401 error.
Two way to fix this.

1, psm_saveLayout change to send get request, this is the easiest way.
2, status page set a csrf key and psm_saveLayout send with the csrf parameter. i fixed in this way.