### PR TITLE
Update Mollie.php with new URL

### DIFF
--- a/src/psm/Txtmsg/Mollie.php
+++ b/src/psm/Txtmsg/Mollie.php
@@ -61,7 +61,7 @@ class Mollie extends Core {
 	public function sendSMS($message) {
 		$recipients = implode(',', $this->recipients);
 
-		$result = $this->_auth_https_post('www.mollie.nl', '/xml/sms/',
+		$result = $this->_auth_https_post('api.messagebird.com', '/xml/sms/',
 							 		'gateway='.urlencode($this->gateway).
 							 		'&username='.urlencode($this->username).
 							 		'&password='.urlencode($this->password).


### PR DESCRIPTION
Mollie has changed their SMS api to api.messagebird.com
They have been redirecting calls to www.mollie.com but will stop doing so from oct 24 2016
The API hasn't changed, this configuration is tested & working (Fixes #370)