### PR TITLE
Add RDP (port 3389) support

### DIFF
--- a/src/lang/de_DE.lang.php
+++ b/src/lang/de_DE.lang.php
@@ -125,6 +125,7 @@ $sm_lang = array(
 		'type' => 'Typ',
 		'type_website' => 'Webseite',
 		'type_service' => 'Service',
+		'type_ping' => 'Ping',
 		'pattern' => 'Suchstring/-muster',
 		'pattern_description' => 'Wenn das gesuchte Muster nicht in der Webseite ist, wird die Seite als offline markiert. Reguläre Ausdrücke sind erlaubt.',
 		'last_check' => 'Letzter Check',

--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -460,6 +460,7 @@ class ServerController extends AbstractServerController {
 			'label_type' => psm_get_lang('servers', 'type'),
 			'label_website' => psm_get_lang('servers', 'type_website'),
 			'label_service' => psm_get_lang('servers', 'type_service'),
+			'label_ping' => psm_get_lang('servers', 'type_ping'),
 			'label_pattern' => psm_get_lang('servers', 'pattern'),
 			'label_pattern_description' => psm_get_lang('servers', 'pattern_description'),
 			'label_last_check' => psm_get_lang('servers', 'last_check'),

--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -286,6 +286,8 @@ class ServerController extends AbstractServerController {
 		        $clean["port"] = 443;
 		    } elseif ($tmp["scheme"] === "http") {
 		        $clean["port"] = 80;
+		    } elseif ($tmp["scheme"] === "rdp") {
+		        $clean["port"] = 3389;
 		    }
 		}
 

--- a/src/psm/Util/Server/ServerValidator.php
+++ b/src/psm/Util/Server/ServerValidator.php
@@ -101,6 +101,11 @@ class ServerValidator {
 					throw new \InvalidArgumentException('server_ip_bad_service');
 				}
 				break;
+			case 'ping':
+				if(!filter_var($value, FILTER_VALIDATE_IP)) {
+					throw new \InvalidArgumentException('server_ip_bad_service');
+				}
+				break;
 		}
 
 		return true;
@@ -113,7 +118,7 @@ class ServerValidator {
 	 * @throws \InvalidArgumentException
 	 */
 	public function type($type) {
-		if(!in_array($type, array('service', 'website'))) {
+		if(!in_array($type, array('ping', 'service', 'website'))) {
 			throw new \InvalidArgumentException('server_type_invalid');
 		}
 		return true;

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -138,7 +138,7 @@ class StatusUpdater {
 	}
 
 	/**
-	 * Check the current servers ping status
+	 * Check the current servers ping status - Code from http://stackoverflow.com/a/20467492
 	 * @param int $max_runs
 	 * @param int $run
 	 * @return boolean

--- a/src/templates/default/module/server/server/update.tpl.html
+++ b/src/templates/default/module/server/server/update.tpl.html
@@ -47,6 +47,7 @@
                         <option value="115">SFTP (115)</option>
                         <option value="43">WHOIS (43)</option>
                         <option value="53">BIND (53)</option>
+                        <option value="3389">RDP (3389)</option>
                     </optgroup>
 				</select>
 			</div>

--- a/src/templates/default/module/server/server/update.tpl.html
+++ b/src/templates/default/module/server/server/update.tpl.html
@@ -20,6 +20,7 @@
 			<div class="controls">
 				<select id="type" name="type">
 					<option value="">{{ label_please_select }}</option>
+					<option value="ping" {{ edit_type_selected_ping|raw }}>{{ label_ping }}</option>
 					<option value="service" {{ edit_type_selected_service|raw }}>{{ label_service }}</option>
 					<option value="website" {{ edit_type_selected_website|raw }}>{{ label_website }}</option>
 				 </select>


### PR DESCRIPTION
Checking if RDP is up can be done by using the same method as when checking other services.
You can also specify the rdp check by specifying rdp:// as protocol in the url. It will be replaced by port 3389 on save. If your RDP is running on another port than 3389, please specify the port on your own.

See http://stackoverflow.com/a/10933311