### PR TITLE
Add type ping to lang file

### DIFF
--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -135,6 +135,7 @@ $sm_lang = array(
 		'type' => 'Type',
 		'type_website' => 'Website',
 		'type_service' => 'Service',
+		'type_ping' => 'Ping',
 		'pattern' => 'Search string/pattern',
 		'pattern_description' => 'If this pattern is not found on the website, the server will be marked offline. Regular expressions are allowed.',
 		'last_check' => 'Last check',


### PR DESCRIPTION
Missed the lang entry in the english language file, should be added to the previous pull request :)
So german and english are done, the other language files are still missing the 
`		'type_ping' => 'Ping',`
entry.