### PR TITLE
Add ping to enum for type column in servers database table

### DIFF
--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -218,7 +218,7 @@ class Installer {
 						  `ip` varchar(500) NOT NULL,
 						  `port` int(5) unsigned NOT NULL,
 						  `label` varchar(255) NOT NULL,
-						  `type` enum('service','website') NOT NULL default 'service',
+						  `type` enum('ping','service','website') NOT NULL default 'service',
 						  `pattern` varchar(255) NOT NULL,
 						  `status` enum('on','off') NOT NULL default 'on',
 						  `error` varchar(255) NULL,


### PR DESCRIPTION
This little thing was missing to save ping to the database.