### PR TITLE
Basic pagespeedsettings + meta noindex + removed meta autor

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,20 @@
 Options -Indexes
+
+<IfModule mod_expires.c>
+ <FilesMatch "\.(js|jpg|jpeg|gif|png|css)$">
+  ExpiresActive on
+  ExpiresDefault "access plus 1 month"
+ </FilesMatch>
+ </IfModule>
+
+<IfModule mod_deflate.c>
+AddOutputFilterByType DEFLATE text/plain
+AddOutputFilterByType DEFLATE text/html
+AddOutputFilterByType DEFLATE text/xml
+AddOutputFilterByType DEFLATE text/css
+AddOutputFilterByType DEFLATE application/xml
+AddOutputFilterByType DEFLATE application/xhtml+xml
+AddOutputFilterByType DEFLATE application/rss+xml
+AddOutputFilterByType DEFLATE application/javascript
+AddOutputFilterByType DEFLATE application/x-javascript
+</IfModule>

--- a/src/templates/default/main/body.tpl.html
+++ b/src/templates/default/main/body.tpl.html
@@ -6,7 +6,7 @@
     <title>{{ title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1">
     <meta name="description" content="">
-    <meta name="author" content="">
+    <meta name="robots" content="noindex" />		
     <meta name="theme-color" content="#424242">
 	<link rel="icon" type="image/x-icon" href="favicon.ico" />
 	<link rel="icon" type="image/png" href="favicon.png" />


### PR DESCRIPTION
- Added some basic pagespeed settings to the htaccess.
- A monitoring website should not be indexed by google. <meta name="robots" content="noindex" /> will prevent that. Added.
- Removed autor-tag, because not relevant anymore (especially for a page like that)