### PR TITLE
Changed mysql pdo port empty check, to fix problem with mysql cant co…

### DIFF
--- a/src/psm/Service/Database.php
+++ b/src/psm/Service/Database.php
@@ -90,7 +90,7 @@ class Database {
 	function __construct($host = null, $user = null, $pass = null, $db = null, $port = null) {
 		if($host != null && $user != null && $pass !== null && $db != null) {
 			$this->db_host = $host;
-			$this->db_port = $port || 3306;
+			$this->db_port = (!empty($port)) ? $port : 3306;
 			$this->db_name = $db;
 			$this->db_user = $user;
 			$this->db_pass = $pass;


### PR DESCRIPTION
Just spotted a problem when installing PHP Server Monitor, for the first time. 

When choosing a custom MySQL port, you will get the error, can't connect to mysql, because the PDO has a option to set default port to 3306, when port is empty, but the check is not good enough, so it would always use 3306. 

My pull-request here will fix this issue.