### PR TITLE
Parameter order fixed to match constructor signature #427

### DIFF
--- a/src/psm/Module/Install/Controller/InstallController.php
+++ b/src/psm/Module/Install/Controller/InstallController.php
@@ -143,10 +143,10 @@ class InstallController extends AbstractController {
 				// test db connection
 				$this->db = new \psm\Service\Database(
 					$config['db_host'],
-          $config['db_port'],
 					$config['db_user'],
 					$config['db_pass'],
-					$config['db_name']
+					$config['db_name'],
+                    $config['db_port']
 				);
 
 				if($this->db->status()) {


### PR DESCRIPTION
Somehow the order of the parameters got mixed up.
the constructor of  \psm\Service\Database expects the port to be the very last parameter instead of the second one