### PR TITLE
Clear log button - closes #383

### DIFF
--- a/src/lang/bg_BG.lang.php
+++ b/src/lang/bg_BG.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Няма налични логове',
+		'clear' => 'Изчистване на дневника',
+		'delete_title' => 'Изтриване на дневника',
+		'delete_message' => 'Наистина ли искате да изтриете <b>всички</b> дневници?',
 	),
 	'servers' => array(
 		'server' => 'Сървър',

--- a/src/lang/cs_CZ.lang.php
+++ b/src/lang/cs_CZ.lang.php
@@ -114,6 +114,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Žádné záznamy',
+		'clear' => 'Jasný protokol',
+		'delete_title' => 'Odstranit protokol',
+		'delete_message' => 'Opravdu chcete odstranit protokoly <b>všechny</b>?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/da_DK.lang.php
+++ b/src/lang/da_DK.lang.php
@@ -111,6 +111,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Intet i loggen',
+		'clear' => 'Ryd log',
+		'delete_title' => 'Slet log',
+		'delete_message' => 'Er du sikker på, at du vil slette <b>alle</b> logfiler?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/de_DE.lang.php
+++ b/src/lang/de_DE.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Keine Logs vorhanden.',
+		'clear' => 'Protokoll Logs',
+		'delete_title' => 'Protokoll Logs',
+		'delete_message' => 'Bist du sicher, dass du <b>alle</b> logs löschen möchtest?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'No logs',
+		'clear' => 'Clear log',
+		'delete_title' => 'Delete log',
+		'delete_message' => 'Are you sure you want to delete <b>all</b> logs?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/es_ES.lang.php
+++ b/src/lang/es_ES.lang.php
@@ -114,7 +114,10 @@ $sm_lang = array(
 		'email' => 'Email',
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
-		'no_logs' => 'No hay registros',
+		'no_logs' => 'No hay journaux',
+		'clear' => 'Borrar registro',
+		'delete_title' => 'Eliminar registro',
+		'delete_message' => '¿Estás seguro de que quieres eliminar <b>todos</b> los registros?',
 	),
 	'servers' => array(
 		'server' => 'Servidores',

--- a/src/lang/et_ET.lang.php
+++ b/src/lang/et_ET.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Logisid ei eksisteeri',
+		'clear' => 'Puhasta logig',
+		'delete_title' => 'Kustuta logi',
+		'delete_message' => 'Kas olete kindel, et soovite kustutada <b>kõik</b> logid?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/fa_IR.lang.php
+++ b/src/lang/fa_IR.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'پیامک',
 		'pushover' => 'Pushover',
 		'no_logs' => 'لاگی وجود ندارد.',
+		'clear' => 'پاک کردن ورود',
+		'delete_title' => 'حذف ورود',
+		'delete_message' => 'آیا مطمئن هستید که میخواهید سیاهههای «همه» را حذف کنید؟',
 	),
 	'servers' => array(
 		'server' => 'سرور',

--- a/src/lang/fi_FI.lang.php
+++ b/src/lang/fi_FI.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'Tekstiviesti',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Ei tapahtumia',
+		'clear' => 'Tyhjennä loki',
+		'delete_title' => 'Poista loki',
+		'delete_message' => 'Haluatko varmasti poistaa <b>kaikki</b> lokit?',
 	),
 	'servers' => array(
 		'server' => 'Palvelin',

--- a/src/lang/fr_FR.lang.php
+++ b/src/lang/fr_FR.lang.php
@@ -114,6 +114,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Aucun événement',
+		'clear' => 'Claire registros',
+		'delete_title' => 'Supprimer journaux',
+		'delete_message' => 'Êtes-vous sûr de vouloir supprimer <b>tous</b> les journaux?',
 	),
 	'servers' => array(
 		'server' => 'Serveur',

--- a/src/lang/it_IT.lang.php
+++ b/src/lang/it_IT.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Nessun log',
+		'clear' => 'Pulisci il registro',
+		'delete_title' => 'Elimina log',
+		'delete_message' => 'Sei sicuro di voler eliminare <b>tutti</b> i registri?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/ja_JP.lang.php
+++ b/src/lang/ja_JP.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'プッシュオーバー',
 		'no_logs' => 'ログがありません',
+		'clear' => 'ログをクリアする',
+		'delete_title' => 'ログを削除する',
+		'delete_message' => 'すべてのログを削除してもよろしいですか？',
 	),
 	'servers' => array(
 		'server' => 'サーバー',

--- a/src/lang/ko_KR.lang.php
+++ b/src/lang/ko_KR.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'sms',
 		'pushover' => 'Pushover',
 		'no_logs' => 'No logs',
+		'clear' => 'Clear log',
+		'delete_title' => 'Delete log',
+		'delete_message' => 'Are you sure you want to delete <b>all</b> logs?',
 	),
 	'servers' => array(
 		'server' => '서버',

--- a/src/lang/nl_NL.lang.php
+++ b/src/lang/nl_NL.lang.php
@@ -112,7 +112,10 @@ $sm_lang = array(
 		'email' => 'Email',
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
-		'no_logs' => 'No logs',
+		'no_logs' => 'Geen logs',
+		'clear' => 'Logboek opschonen',
+		'delete_title' => 'Logboek opschonen',
+		'delete_message' => 'Weet je zeker dat je <b>alle</b> logs wilt opschonen?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/pl_PL.lang.php
+++ b/src/lang/pl_PL.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Brak logów',
+		'clear' => 'Wyczyść log',
+		'delete_title' => 'Wyczyść log',
+		'delete_message' => 'Czy na pewno chcesz usunąć <b>wszystkie</b> dzienniki?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/pt_BR.lang.php
+++ b/src/lang/pt_BR.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
         'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Sem logs',
+		'clear' => 'Log clara',
+		'delete_title' => 'Log clara',
+		'delete_message' => 'Tem certeza de que deseja excluir <b>todos</b> os logs?',
     ),
     'servers' => array(
         'server' => 'Servidor',

--- a/src/lang/ru_RU.lang.php
+++ b/src/lang/ru_RU.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Записей нет',
+		'clear' => 'Clear log',
+		'delete_title' => 'Delete log',
+		'delete_message' => 'Are you sure you want to delete <b>all</b> logs?',
 	),
 	'servers' => array(
 		'server' => 'Сервер',

--- a/src/lang/sk_SK.lang.php
+++ b/src/lang/sk_SK.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Žiadne záznamy',
+		'clear' => 'Jasný protokol',
+		'delete_title' => 'Jasný protokol',
+		'delete_message' => 'Naozaj chcete odstrániť <b>všetky</b> záznamy?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/sl_SI.lang.php
+++ b/src/lang/sl_SI.lang.php
@@ -111,6 +111,9 @@ $sm_lang = array(
         'sms' => 'SMS',
         'pushover' => 'Pushover',
         'no_logs' => 'ni dnevniških zapisov',
+        'clear' => 'Počisti dnevnik',
+    		'delete_title' => 'Brisanje dnevnika',
+    		'delete_message' => 'Ali ste prepričani, da želite izbrisati <b>vse</b> dnevnike?',
     ),
     'servers' => array(
         'server' => 'Strežnik',

--- a/src/lang/sv_SE.lang.php
+++ b/src/lang/sv_SE.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'Inga loggar',
+		'clear' => 'Tydlig logg',
+		'delete_title' => 'Tydlig logg',
+		'delete_message' => 'Är du säker på att du vill radera <b>alla</b> loggar?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/tr_TR.lang.php
+++ b/src/lang/tr_TR.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
         'sms' => 'SMS',
         'pushover' => 'Pushover',
         'no_logs' => 'Kayıt yok.',
+        'clear' => 'Günlüğü temizle',
+    		'delete_title' => 'Günlüğü temizle',
+    		'delete_message' => 'Tüm günlükleri silmek istediğinizden emin misiniz?',
     ),
     'servers' => array(
         'server' => 'Sunucu',

--- a/src/lang/vi_VN.lang.php
+++ b/src/lang/vi_VN.lang.php
@@ -111,6 +111,9 @@ $sm_lang = array(
 		'sms' => 'SMS',
 		'pushover' => 'Pushover',
 		'no_logs' => 'No logs',
+		'clear' => 'Xoá nhật ký',
+		'delete_title' => 'Xoá nhật ký',
+		'delete_message' => 'Bạn có chắc chắn muốn xóa <b>tất</b> cả các bản ghi?',
 	),
 	'servers' => array(
 		'server' => 'Server',

--- a/src/lang/zh_CN.lang.php
+++ b/src/lang/zh_CN.lang.php
@@ -113,6 +113,9 @@ $sm_lang = array(
 		'sms' => '短信',
 		'pushover' => 'Pushover',
 		'no_logs' => '没有日志',
+		'clear' => 'Clear log',
+		'delete_title' => 'Delete log',
+		'delete_message' => 'Are you sure you want to delete <b>all</b> logs?',
 	),
 	'servers' => array(
 		'server' => '业务',

--- a/src/psm/Util/Server/Archiver/LogsArchiver.php
+++ b/src/psm/Util/Server/Archiver/LogsArchiver.php
@@ -67,4 +67,13 @@ class LogsArchiver implements ArchiverInterface {
 		);
 		return true;
 	}
+
+	/**
+	 * Empty tables log and log_users
+	 */
+	public function cleanupall() {
+		$this->db->delete(PSM_DB_PREFIX . "log");
+		$this->db->delete(PSM_DB_PREFIX . "log_users");
+		return true;
+	}
 }

--- a/src/templates/default/module/server/log.tpl.html
+++ b/src/templates/default/module/server/log.tpl.html
@@ -1,3 +1,9 @@
+{% if has_admin_actions %}
+<a class="btn btn-danger show-modal" href="{{ url_delete|raw }}" title="Delete" data-modal-id="delete" data-modal-param="{{ label }}">
+	<i class="icon-trash icon-white"></i>&nbsp;{{ label_clear_log }}
+</a>
+<br><br>
+{% endif %}
 <div class="tabbable">
 	<ul class="nav nav-tabs">
 		<li class="active"><a href="#log_status_content" data-toggle="tab">{{ label_status }}</a></li>


### PR DESCRIPTION
As requested in issue #383. 
By pushing the button on the log page you, as an admin, delete _all_ logs. 
The content of the log and log_users table will be deleted.