### PR TITLE
Memory errors when running on small PHP Servers

### DIFF
--- a/src/psm/Util/Server/UpdateManager.php
+++ b/src/psm/Util/Server/UpdateManager.php
@@ -71,11 +71,11 @@ class UpdateManager extends ContainerAware {
 			$status_new = $updater->update($server['server_id']);
 			// notify the nerds if applicable
 			$notifier->notify($server['server_id'], $status_old, $status_new);
-		}
 
-		// clean-up time!! archive all records
-		$archive = new ArchiveManager($this->container->get('db'));
-		$archive->archive();
-		$archive->cleanup();
+		   // clean-up time!! archive all records
+		   $archive = new ArchiveManager($this->container->get('db'));
+		   $archive->archive($server['server_id']);
+		   $archive->cleanup($server['server_id']);
+		}
 	}
 }


### PR DESCRIPTION
One of our webservers runs with 10MB memory space which quickly results in issues with the archive call for all servers and single servers. 

In psm/Util/Server/Archiver/UptimeArchiver.php::archive all uptime events older than 7 days are requested. In our case this results quickly in the cronjob as well as single server views (which call the archive for a single server) to fail due to exhausting the available memory. We monitor about 200 servers every 10 minutes generating ~29,000 uptime events a day. When the conjob fails to archive all of them at the same time and the server view (mod=server&action=view) is not visited, these events accumulate.

My fix moves the archive code into the for loop which pings every server and archives/cleans up each server instance separately. This reduces the memory load for every archive to the server relevant uptime events. Unfortunately most of the day, this code path won't do anything (because events older than 7 days are archived once a day - usually with the first cron invocation). Another solution could count the existing entries which are older than 7 days and only if one exists, run this code path.

Please let me know, if you have questions, regarding the issue or update.