### PR TITLE
Allow periods in usernames since the install also allows it

### DIFF
--- a/src/psm/Util/User/UserValidator.php
+++ b/src/psm/Util/User/UserValidator.php
@@ -21,7 +21,7 @@
  * @author      Pepijn Over <pep@mailbox.org>
  * @copyright   Copyright (c) 2008-2017 Pepijn Over <pep@mailbox.org>
  * @license     http://www.gnu.org/licenses/gpl.txt GNU GPL v3
- * @version     Release: @package_version@
+ * @version     Release: v3.2.0
  * @link        http://www.phpservermonitor.org/
  * @since       phpservermon 3.0.0
  **/
@@ -67,7 +67,7 @@ class UserValidator {
 	 * Check username on:
 	 *
 	 * - Length (2-64 chars)
-	 * - Contents (alphabetic chars and digits only)
+	 * - Contents (alphabetic chars and digits only as well as periods "." as in "adduser --force-badname")
 	 * - Unique
 	 * @param string $username
 	 * @param int $user_id to check whether the username is unique
@@ -78,7 +78,7 @@ class UserValidator {
 		if(strlen($username) > 64 || strlen($username) < 2) {
             throw new \InvalidArgumentException('user_name_bad_length');
         }
-		if (!preg_match('/^[a-zA-Z\d_\.]{2,64}$/i', $username)) {
+		if (!preg_match('/^[a-zA-Z\d_\d.]{2,64}$/i', $username)) {
             throw new \InvalidArgumentException('user_name_invalid');
 		}
 		$user_exists = $this->user->getUserByUsername($username);
@@ -107,30 +107,11 @@ class UserValidator {
 	}
 
 	/**
-	* Install only; Check username on:
-	*
-	* - Length (2-64 chars)
-	* - Contents (alphabetic chars and digits only)
-	* @param string $username
-	* @return boolean
-	* @throws \InvalidArgumentException
-	*/
-	public function username_new($username) {
-		if(strlen($username) > 64 || strlen($username) < 2) {
-			throw new \InvalidArgumentException('user_name_bad_length');
-		}
-		if (!preg_match('/^[a-zA-Z\d_\.]{2,64}$/i', $username)) {
-			throw new \InvalidArgumentException('user_name_invalid');
-		}
-		return true;
-	}
-
-	/**
-	* Check email
-	* @param string $email
-	* @return boolean
-	* @throws \InvalidArgumentException
-	*/
+	 * Check email
+	 * @param string $email
+	 * @return boolean
+	 * @throws \InvalidArgumentException
+	 */
 	public function email($email) {
 		if(strlen($email) > 255 || strlen($email) < 5) {
 			throw new \InvalidArgumentException('user_email_bad_length');


### PR DESCRIPTION
The user creation during the setup allows for a username to contain periods (.) just as adduser --force-badname would do. This is helpful if your naming standard uses periods in usernames. However, such a user cannot be edited anymore, as soon as a change is made on it, it will trigger the error "The username may only contain alphabetic characters (a-z, A-Z), digits (0-9) and underscores (_).". Updated REGEX to allow this (TODO update error messages)