### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.vagrant/
 /puphpet/files/dot/ssh/
 *.bak
+__MACOSX/


### PR DESCRIPTION
added __MACOSX to .gitignore

Current Release 3.2.2 does have many .files under __MACOSX

  inflating: __MACOSX/phpservermon-3.2.2/src/._templates
  inflating: __MACOSX/phpservermon-3.2.2/._src
  inflating: __MACOSX/._phpservermon-3.2.2