### PR TITLE
Added rdp:// and fixed port update #418

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 Not yet released
 ----------------
 
+#629: Fix bug that made it impossible to check rdp:// and fixed port update.
+b49659f: Added question to notification faq about not recieving notifications.
+ef28908: Indentation fix.
+#605: Added Norwegian language.
+f6173d4: Added license to composer.json file.
+
 v3.3.1 (released August 10, 2018)
 --------------------------------
 

--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -278,15 +278,15 @@ class ServerController extends AbstractServerController {
 			'telegram' => in_array($_POST['telegram'], array('yes', 'no')) ? $_POST['telegram'] : 'no',
 		);
 		// make sure websites start with http://
-		if ($clean['type'] == 'website' && substr($clean['ip'], 0, 4) != 'http') {
+		if ($clean['type'] == 'website' && substr($clean['ip'], 0, 4) != 'http' && substr($clean['ip'], 0, 3) != 'rdp') {
 			$clean['ip'] = 'http://'.$clean['ip'];
 		}
 
 		// validate the lot
 		$server_validator = new \psm\Util\Server\ServerValidator($this->db);
 
-		// format port from http/s url
-		if ($clean['type'] == 'website' && empty($clean['port'])) {
+		// format port from http, https or rdp url
+		if ($clean['type'] == 'website') {
 			$tmp = parse_url($clean["ip"]);
 			if (isset($tmp["port"])) {
 				$clean["port"] = $tmp["port"];


### PR DESCRIPTION
Fixes #418.

- Although the port isn't used while testing a website, changing it prevents confusion.
- It seems like rdp:// was supported, but starting a URL with it wasn't...