### PR TITLE
Downgraded symfony/filesystem to ~3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Not yet released
 ----------------
-
+* #656: Downgraded symfony/filesystem to ~3.4 (PHP 5.5.9 compatible) and added 7.0.8 as minimal PHP7 version.
 * #653: Fixes wrong default type in upgrade/install query.
 * #642: Added post field as addition to #631.
 * #644: Fixed urlencoding in Nexmo message

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,8 @@ Requirements
 
 * Web server
 * MySQL database
-* PHP 5.5.9+
+* For PHP5: 5.5.9+
+* For PHP7: 7.0.8+
 * PHP cURL package
 * PHP PDO mysql driver
 * PHP-XML

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://www.phpservermonitor.org",
 	"require": {
-		"php": ">=5.5.9",
+		"php": "^5.5.9|>=7.0.8",
 		"ext-curl": "*",
 		"ext-pdo": "*",
 		"ext-xml": "*",
@@ -13,6 +13,7 @@
 		"symfony/dependency-injection": "~3.4",
 		"symfony/event-dispatcher": "~3.4",
 		"symfony/http-foundation": "~3.4",
+		"symfony/filesystem": "~3.4",
 		"php-pushover/php-pushover": "dev-master",
 		"paragonie/random_compat": "^2.0",
 		"twig/twig": "~1.35"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b116489d45aab7506cedf3f94fb60ee4",
+    "content-hash": "d20236a69bef1e5b7bf138701a2b8ceb",
     "packages": [
         {
             "name": "paragonie/random_compat",
@@ -400,26 +400,26 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.4",
+            "version": "v3.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e"
+                "reference": "285ce5005cb01a0aeaa5b0cf590bd0cc40bb631c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/285ce5005cb01a0aeaa5b0cf590bd0cc40bb631c",
+                "reference": "285ce5005cb01a0aeaa5b0cf590bd0cc40bb631c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -446,7 +446,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-18T16:52:46+00:00"
+            "time": "2018-08-10T07:29:05+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -754,7 +754,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9",
+        "php": "^5.5.9|>=7.0.8",
         "ext-curl": "*",
         "ext-pdo": "*",
         "ext-xml": "*"

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -5,6 +5,7 @@ Requirements
 
 * Web server
 * MySQL database
-* PHP 5.5.9+
+* For PHP5: 5.5.9+
+* For PHP7: 7.0.8+
 * PHP cURL package
 * PHP PDO mysql driver

--- a/src/psm/Module/Install/Controller/InstallController.php
+++ b/src/psm/Module/Install/Controller/InstallController.php
@@ -69,9 +69,9 @@ class InstallController extends AbstractController {
 		$errors = 0;
 
 		$phpv = phpversion();
-		if (version_compare($phpv, '5.5.9', '<')) {
+		if (version_compare($phpv, '5.5.9', '<') || (version_compare($phpv, '7.0.8', '<') && version_compare($phpv, '7.0.0', '>='))) {
 			$errors++;
-			$this->addMessage('PHP 5.5.9+ is required to run PHP Server Monitor. You\'re using '.$phpv.'.', 'error');
+			$this->addMessage('PHP 5.5.9+ or 7.0.8+ is required to run PHP Server Monitor. You\'re using '.$phpv.'.', 'error');
 		} else {
 			$this->addMessage('PHP version: '.$phpv, 'success');
 		}


### PR DESCRIPTION
Fixes #655.
Downgraded symfony/filesystem to v3.4 (PHP 5.5.9 compatible).
Added 7.0.8 as minimal PHP version for PHP7.