### PR TITLE
Fix #672 Allow HTTP/2 status responses

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -253,18 +253,18 @@ class StatusUpdater {
 		// the first line would be the status code..
 		$status_code = strtok($curl_result, "\r\n");
 		// keep it general
-		// $code[1][0] = status code
-		// $code[2][0] = name of status code
+		// $code[2][0] = status code
+		// $code[3][0] = name of status code
 		$code_matches = array();
-		preg_match_all("/[A-Z]{2,5}\/\d\.\d\s(\d{3})\s(.*)/", $status_code, $code_matches);
+		preg_match_all("/[A-Z]{2,5}\/\d(\.\d)?\s(\d{3})\s?(.*)/", $status_code, $code_matches);
 
-		if (empty($code_matches[0])) {
+		if(empty($code_matches[0])) {
 			// somehow we dont have a proper response.
 			$this->error = 'TIMEOUT ERROR: no response from server';
 			$result = false;
 		} else {
-			$code = $code_matches[1][0];
-			$msg = $code_matches[2][0];
+			$code = $code_matches[2][0];
+			$msg = $code_matches[3][0];
 
 			$allow_http_status = explode("|", $this->server['allow_http_status']);
 			// All status codes starting with a 4 or higher mean trouble!


### PR DESCRIPTION
There will not be a msg for http2 responses, but they are accepted and the code is recognized with this change in the regex.
Fixes #672 