### PR TITLE
Issue #734

### DIFF
--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -453,6 +453,20 @@ class ServerController extends AbstractServerController {
 				'label' => $server_available['label'],
 			);
 		}
+                
+		$tpl_data['last_output_truncated'] = $tpl_data['last_output'];
+		$tpl_data['last_error_output_truncated'] = $tpl_data['last_error_output'];
+                
+		if (strlen($tpl_data['last_output']) > 255) {
+			$tpl_data['last_output_truncated'] = substr($tpl_data['last_output'], 0, 255) . '...';
+                        $tpl_data['last_output'] = nl2br($tpl_data['last_output']);
+		}
+                
+		if (strlen($tpl_data['last_error_output']) > 255) {
+			$tpl_data['last_error_output_truncated'] = nl2br(substr($tpl_data['last_error_output'], 0, 255) . '...');
+                        $tpl_data['last_error_output'] = nl2br($tpl_data['last_error_output']);
+		}
+                
 		return $this->twig->render('module/server/server/view.tpl.html', $tpl_data);
 	}
 

--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -459,12 +459,10 @@ class ServerController extends AbstractServerController {
                 
 		if (strlen($tpl_data['last_output']) > 255) {
 			$tpl_data['last_output_truncated'] = substr($tpl_data['last_output'], 0, 255) . '...';
-                        $tpl_data['last_output'] = nl2br($tpl_data['last_output']);
 		}
                 
 		if (strlen($tpl_data['last_error_output']) > 255) {
-			$tpl_data['last_error_output_truncated'] = nl2br(substr($tpl_data['last_error_output'], 0, 255) . '...');
-                        $tpl_data['last_error_output'] = nl2br($tpl_data['last_error_output']);
+			$tpl_data['last_error_output_truncated'] = substr($tpl_data['last_error_output'], 0, 255) . '...';
 		}
                 
 		return $this->twig->render('module/server/server/view.tpl.html', $tpl_data);

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -238,7 +238,7 @@
 						<dt class="col-md-3"></dt>
 						<dd class="col-md-9">
 							<button type="button" class="btn btn-link" style="float: right;" data-toggle="modal" data-target="#modal_last_output">
-								See complete...
+								Show more...
 							</button>
 						</dd>
 						{% endif %}
@@ -252,7 +252,7 @@
 						<dt class="col-md-3"></dt>
 						<dd class="col-md-9">
 							<button type="button" class="btn btn-link" style="float: right;" data-toggle="modal" data-target="#modal_last_error">
-								See complete...
+								Show more...
 							</button>
 						</dd>
 						{% endif %}
@@ -347,7 +347,7 @@
 						<span aria-hidden="true">&times;</span>
 					</button>
 				</div>
-				<div class="modal-body" style="word-wrap: break-word;font-family: Mono">
+				<div class="modal-body" style="word-wrap: break-word;">
 					{{ last_output|nl2br }}
 				</div>
 				<div class="modal-footer">
@@ -366,7 +366,7 @@
 						<span aria-hidden="true">&times;</span>
 					</button>
 				</div>
-				<div class="modal-body" style="word-wrap: break-word;font-family: Mono">
+				<div class="modal-body" style="word-wrap: break-word;">
 					{{ last_error_output|nl2br }}
 				</div>
 				<div class="modal-footer">

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -233,13 +233,24 @@
 				<li class="list-group-item">
 					<dl class="row">
 						<dt class="col-md-3">{{ label_last_output }}:</dt>
-						<dd class="col-md-9">{{ last_output }}</dd>
+						<dd class="col-md-9">{{ last_output_truncated }}</dd>
+						{% if last_output_truncated != last_output %}
+						<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal_last_output">
+							See complete...
+						</button>
+						{% endif %}
 					</dl>
 				</li>
 				<li class="list-group-item">
 					<dl class="row">
 						<dt class="col-md-3">{{ label_last_error_output }}:</dt>
-						<dd class="col-md-9">{{ last_error_output }}</dd>
+						<dd class="col-md-9">{{ last_error_output_truncated }}</dd>
+						{% if last_error_output_truncated != last_error_output %}
+						<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal_last_error">
+							See complete...
+						</button>
+						{% endif %}
+
 					</dl>
 				</li>
 			</ul>

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -235,9 +235,10 @@
 						<dt class="col-md-3">{{ label_last_output }}:</dt>
 						<dd class="col-md-9">{{ last_output_truncated }}</dd>
 						{% if last_output_truncated != last_output %}
-						<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal_last_output">
-							See complete...
-						</button>
+						<dt class="col-md-3"></dt>
+						<dd class="col-md-9">
+							<a style="float: right;" data-toggle="modal" data-target="#modal_last_output">See complete...</a>
+						</dd>
 						{% endif %}
 					</dl>
 				</li>
@@ -246,9 +247,10 @@
 						<dt class="col-md-3">{{ label_last_error_output }}:</dt>
 						<dd class="col-md-9">{{ last_error_output_truncated }}</dd>
 						{% if last_error_output_truncated != last_error_output %}
-						<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal_last_error">
-							See complete...
-						</button>
+						<dt class="col-md-3"></dt>
+						<dd class="col-md-9">
+							<a style="float: right;" data-toggle="modal" data-target="#modal_last_error">See complete...</a>
+						</dd>
 						{% endif %}
 
 					</dl>

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -335,7 +335,7 @@
 	</div>
 
 	<div class="modal fade" id="modal_last_output" tabindex="-1" role="dialog" aria-labelledby="modal_last_output_label" aria-hidden="true">
-		<div class="modal-dialog" role="document">
+		<div class="modal-dialog" style="width:75%;max-width: 100%" role="document">
 			<div class="modal-content">
 				<div class="modal-header">
 					<h5 class="modal-title" id="modal_last_output_label">{{ label_last_output }}</h5>
@@ -343,8 +343,8 @@
 						<span aria-hidden="true">&times;</span>
 					</button>
 				</div>
-				<div class="modal-body" style="word-wrap: break-word;">
-					{{ last_output }}
+				<div class="modal-body" style="word-wrap: break-word;font-family: Mono">
+					{{ last_output|nl2br }}
 				</div>
 				<div class="modal-footer">
 					<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
@@ -354,7 +354,7 @@
 	</div>
     
 	<div class="modal fade" id="modal_last_error" tabindex="-1" role="dialog" aria-labelledby="modal_last_error_label" aria-hidden="true">
-		<div class="modal-dialog" role="document">
+		<div class="modal-dialog" style="width:75%;max-width: 100%" role="document">
 			<div class="modal-content">
 				<div class="modal-header">
 					<h5 class="modal-title" id="modal_last_error_label">{{ label_last_error_output }}</h5>
@@ -362,8 +362,8 @@
 						<span aria-hidden="true">&times;</span>
 					</button>
 				</div>
-				<div class="modal-body" style="word-wrap: break-word;">
-					{{ last_error_output }}
+				<div class="modal-body" style="word-wrap: break-word;font-family: Mono">
+					{{ last_error_output|nl2br }}
 				</div>
 				<div class="modal-footer">
 					<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -237,7 +237,9 @@
 						{% if last_output_truncated != last_output %}
 						<dt class="col-md-3"></dt>
 						<dd class="col-md-9">
-							<a style="float: right;" data-toggle="modal" data-target="#modal_last_output">See complete...</a>
+							<button type="button" class="btn btn-link" style="float: right;" data-toggle="modal" data-target="#modal_last_output">
+								See complete...
+							</button>
 						</dd>
 						{% endif %}
 					</dl>
@@ -249,7 +251,9 @@
 						{% if last_error_output_truncated != last_error_output %}
 						<dt class="col-md-3"></dt>
 						<dd class="col-md-9">
-							<a style="float: right;" data-toggle="modal" data-target="#modal_last_error">See complete...</a>
+							<button type="button" class="btn btn-link" style="float: right;" data-toggle="modal" data-target="#modal_last_error">
+								See complete...
+							</button>
 						</dd>
 						{% endif %}
 

--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -320,4 +320,42 @@
 	<div class="row">
 		{{ html_history|raw }}
 	</div>
+
+	<div class="modal fade" id="modal_last_output" tabindex="-1" role="dialog" aria-labelledby="modal_last_output_label" aria-hidden="true">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="modal_last_output_label">{{ label_last_output }}</h5>
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+				</div>
+				<div class="modal-body" style="word-wrap: break-word;">
+					{{ last_output }}
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+				</div>
+			</div>
+		</div>
+	</div>
+    
+	<div class="modal fade" id="modal_last_error" tabindex="-1" role="dialog" aria-labelledby="modal_last_error_label" aria-hidden="true">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="modal_last_error_label">{{ label_last_error_output }}</h5>
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+				</div>
+				<div class="modal-body" style="word-wrap: break-word;">
+					{{ last_error_output }}
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
In an attempt to fix #734, this PR truncates the outputs if necessary, then show a `See complete...` button and show the outputs on a modal:

![Screenshot from 2019-06-05 20-22-14](https://user-images.githubusercontent.com/709639/58996946-b029fd80-87d0-11e9-8c53-07c85e95a958.png)

![Screenshot from 2019-06-05 20-22-51](https://user-images.githubusercontent.com/709639/58996948-b15b2a80-87d0-11e9-9bcb-35af5518e59a.png)
