### PR TITLE
Update requirements.rst

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -9,3 +9,4 @@ Requirements
 * For PHP7: 7.0.8+
 * PHP cURL package
 * PHP PDO mysql driver
+* PHP XML package


### PR DESCRIPTION
On stock Debian 9.9, "apt-get install php-xml" is needed to get anything to load. Here is the error you get without it: (Extension DOM is required. in /var/www/html/vendor/symfony/config/Util/XmlUtils.php:50)