### PR TITLE
"Last online" stuck on "never" when checking some websites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ PHP Server Monitor
    :alt: Join the chat at https://gitter.im/erickrf/nlpnet
    :target: https://gitter.im/phpservermon/phpservermon
 
-Version 3.4.0 (Updated design!)
+Version 3.4.1 (Updated design!)
 
 
 PHP Server Monitor is a script that checks whether your websites and servers are up and running.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ copyright = u'2008-2017, Pepijn Over'
 # built documents.
 #
 # The short X.Y version.
-version = '3.4.0'
+version = '3.4.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/src/includes/psmconfig.inc.php
+++ b/src/includes/psmconfig.inc.php
@@ -29,7 +29,7 @@
 /**
  * Current PSM version
  */
-define('PSM_VERSION', '3.4.0');
+define('PSM_VERSION', '3.4.1');
 
 /**
  * URL to check for updates. Will not be checked if turned off on config page.

--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -573,4 +573,17 @@ class Installer {
 		$this->execSQL($queries);
 		$this->log('Combined notifications enabled. Check out the config page for more info.');
 	}
+	/**
+	 * Patch for v3.4.1 release
+	 */
+	protected function upgrade341() {
+		$queries = array();
+		/** 
+		 * Redirect_check is first set to default ok.
+		 * If you have a lot of server that are redirecting, 
+		 * this will make sure you're servers stay online.
+		 */
+		$queries[] = "ALTER TABLE `".PSM_DB_PREFIX."servers` ALTER COLUMN `last_output` text;";
+		$this->execSQL($queries);
+	}
 }

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -152,7 +152,15 @@ class StatusUpdater {
 				}
 			}
 		}
-
+		// PATCH Arkhee : fix/last-online-stuck-on-never-if-webpage-too-large
+		// TThe update un "servers" table does not work
+		// Symptom : "Last online" stays stuck on "never"
+		// Reason: last_output contains the full webpage, too long for the query
+		// _This may depend on mysql configuration on the server_, explaining why some have the problem or not
+		// Field is 255 Chars, and request does not work anyway is loaded web page is too large in last_output
+		// So force truncate to 250 or less before query
+		$save["last_output"]=substr($save["last_output"],0,250);
+		// End PATCH
 		$this->db->save(PSM_DB_PREFIX.'servers', $save, array('server_id' => $this->server_id));
 
 		return $this->status_new;

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -152,11 +152,11 @@ class StatusUpdater {
 				}
 			}
 		}
-		// PATCH Arkhee : fix/last-online-stuck-on-never-if-webpage-too-large
-		// TThe update un "servers" table does not work
-		// Symptom : "Last online" stays stuck on "never"
+		// PATCH Arkhee: fix/last-online-stuck-on-never-if-webpage-too-large
+		// Updating table "servers" does not work
+		// Symptom: "Last online" stays stuck on "never"
 		// Reason: last_output contains the full webpage, too long for the query
-		// _This may depend on mysql configuration on the server_, explaining why some have the problem or not
+		// This may depend on mysql configuration on the server_, explaining why some have the problem or not
 		// Field is 255 Chars, and request does not work anyway is loaded web page is too large in last_output
 		// So force truncate to 250 or less before query
 		$save["last_output"]=substr($save["last_output"],0,250);

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -158,8 +158,8 @@ class StatusUpdater {
 		// Reason: last_output contains the full webpage, too long for the query
 		// This may depend on mysql configuration on the server_, explaining why some have the problem or not
 		// Field is 255 Chars, and request does not work anyway is loaded web page is too large in last_output
-		// So force truncate to 250 or less before query
-		$save["last_output"]=substr($save["last_output"],0,250);
+		// Solution: updated column to text and truncate to 5000 characters or less before the query
+		$save["last_output"] = substr($save["last_output"],0,5000);
 		// End PATCH
 		$this->db->save(PSM_DB_PREFIX.'servers', $save, array('server_id' => $this->server_id));
 


### PR DESCRIPTION
Some users (included me) noticed some kind of random behavior when checking web page : ususally the server status would not update

This is probably due to mysql server configuration regarding the size of the data which is inserted in a text field : server monitor stores the full loaded webpage, sometimes the query field is too big, even when setting "last_output" to "text" instead of "varchar", the error may depend on a mysql setting.

So since the field is varchar 255, the solution is juste to truncate the data to 255 or lower before save
