### PR TITLE
Fix Server Downtime is displayed incorrectly

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -144,7 +144,6 @@ class StatusUpdater
         } else {
             // server is offline, increase the error counter and set last offline
             $save['warning_threshold_counter'] = $this->server['warning_threshold_counter'] + 1;
-            $save['last_offline'] = date('Y-m-d H:i:s');
             $save['last_error_output'] = empty($this->header) ?
                 "Could not get headers. probably HTTP 50x error." : $this->header;
 


### PR DESCRIPTION
Server Downtime is displayed in correctly when receiveing e-mails about it.