### PR TITLE
fixes #824 user creation privilege issue & error message

### DIFF
--- a/src/psm/Module/User/Controller/UserController.php
+++ b/src/psm/Module/User/Controller/UserController.php
@@ -295,6 +295,13 @@ class UserController extends AbstractController
         if ($user_id > 0) {
             // edit user
             unset($clean['password']); // password update is executed separately
+            if (
+                count($this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN))) == 1 &&
+                    $this->getUser()->getUserLevel() == PSM_USER_ADMIN
+            ) {
+                $this->addMessage(psm_get_lang('users', 'error_user_admin_cant_be_deleted'), 'warning');
+                $clean['level'] = PSM_USER_ADMIN;
+            }
             $this->db->save(PSM_DB_PREFIX . 'users', $clean, array('user_id' => $user_id));
             $this->addMessage(psm_get_lang('users', 'updated'), 'success');
 

--- a/src/psm/Module/User/Controller/UserController.php
+++ b/src/psm/Module/User/Controller/UserController.php
@@ -269,7 +269,7 @@ class UserController extends AbstractController
         }
 
         $user_validator = $this->container->get('util.user.validator');
-        
+
         try {
             $user_validator->username($clean['user_name'], $user_id);
             $user_validator->email($clean['email']);

--- a/src/psm/Module/User/Controller/UserController.php
+++ b/src/psm/Module/User/Controller/UserController.php
@@ -295,9 +295,11 @@ class UserController extends AbstractController
         if ($user_id > 0) {
             // edit user
             unset($clean['password']); // password update is executed separately
+            $admins = $this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN));
             if (
-                count($this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN))) == 1 &&
-                    $this->getUser()->getUserLevel() == PSM_USER_ADMIN
+                (int) count($admins) === (int) 1 &&
+                (int) $admins[0]['user_id'] === (int) $user_id &&
+                (int) $clean['level'] === (int) PSM_USER_USER
             ) {
                 $this->addMessage(psm_get_lang('users', 'error_user_admin_cant_be_deleted'), 'warning');
                 $clean['level'] = PSM_USER_ADMIN;
@@ -352,7 +354,11 @@ class UserController extends AbstractController
         try {
             $this->container->get('util.user.validator')->userId($id);
 
-            if (count($this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN))) == 1) {
+            $admins = $this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN));
+            if (
+                (int) count($admins) === (int) 1 &&
+                (int) $admins[0]['user_id'] === (int) $id
+            ) {
                 $this->addMessage(psm_get_lang('users', 'error_user_admin_cant_be_deleted'), 'error');
             } else {
                 $this->db->delete(PSM_DB_PREFIX . 'users', array('user_id' => $id,));

--- a/src/psm/Module/User/Controller/UserController.php
+++ b/src/psm/Module/User/Controller/UserController.php
@@ -269,18 +269,11 @@ class UserController extends AbstractController
         }
 
         $user_validator = $this->container->get('util.user.validator');
-
+        
         try {
             $user_validator->username($clean['user_name'], $user_id);
             $user_validator->email($clean['email']);
             $user_validator->level($clean['level']);
-            if (
-                count($this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN))) == 1 &&
-                    $this->getUser()->getUserLevel() == PSM_USER_ADMIN
-            ) {
-                $this->addMessage(psm_get_lang('users', 'error_user_admin_cant_be_deleted'), 'warning');
-                $clean['level'] = PSM_USER_ADMIN;
-            }
 
             // always validate password for new users,
             // but only validate it for existing users when they change it.


### PR DESCRIPTION
I removed this code as it seemed redundant as we are creating a user and if we only have one user who is an admin it would evaluate to true when we're not deleting a user. The following code exists in the executeDelete as a safeguard already.
```
            if (
                count($this->db->select(PSM_DB_PREFIX . 'users', array('level' => PSM_USER_ADMIN))) == 1 &&
                    $this->getUser()->getUserLevel() == PSM_USER_ADMIN
            ) {
                $this->addMessage(psm_get_lang('users', 'error_user_admin_cant_be_deleted'), 'warning');
                $clean['level'] = PSM_USER_ADMIN;
            }
```