### PR TITLE
Hotfix/check ssl

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -406,7 +406,7 @@ class StatusUpdater
      */
     private function checkSsl($server, &$error, &$result)
     {
-        if (version_compare(PHP_RELEASE_VERSION, '7.1', '<')) {
+        if (version_compare(PHP_VERSION, '7.1', '<')) {
             $error = "The server you're running PSM on must use PHP 7.1 or higher to test the SSL expiration.";
             return;
         }

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -366,8 +366,10 @@ class StatusUpdater
             }
         }
 
-        // Check ssl cert
-        $this->checkSsl($this->server, $this->error, $result);
+        // Check ssl cert just when other error is not already in...
+	    if ($result !== false) {
+		    $this->checkSsl($this->server, $this->error, $result);
+	    }
 
         // check if server is available and rerun if asked.
         if (!$result && $run < $max_runs) {

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -367,9 +367,9 @@ class StatusUpdater
         }
 
         // Check ssl cert just when other error is not already in...
-	    if ($result !== false) {
-		    $this->checkSsl($this->server, $this->error, $result);
-	    }
+        if ($result !== false) {
+            $this->checkSsl($this->server, $this->error, $result);
+        }
 
         // check if server is available and rerun if asked.
         if (!$result && $run < $max_runs) {


### PR DESCRIPTION
Fix of bug #849. `checkSsl` should be called only when other error is not already in place and should compare PHP version in the right way (`PHP_VERSION`, not `PHP_RELEASE_VERSION`).