### PR TITLE
Prevent loading main page if installed in subdirectory (fix #869)

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 var dataCacheName = 'PSM-v1';
 var cacheName = 'PSM-PWA-final-1';
 var filesToCache = [
-  '/',
+  '',
   'index.php',
   'src/templates/default/static/js/history.js',
   'src/templates/default/static/js/scripts.js',


### PR DESCRIPTION
When installed in a subdirectory the service-worker should not load (and cache) "/" but "" instead.