### PR TITLE
[BUG] Fail to ping IPv6 #879

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.bak
 __MACOSX/
 .DS_Store
+.buildpath
+.settings/

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -178,7 +178,7 @@ class StatusUpdater
         if ($max_runs == null || $max_runs > 1) {
             $max_runs = 1;
         }
-        $result = null; 
+        $result = null;
         // Execute ping
         $pingCommand = 'ping6';
         $serverIp = $this->server['ip'];

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -178,9 +178,14 @@ class StatusUpdater
         if ($max_runs == null || $max_runs > 1) {
             $max_runs = 1;
         }
-        $result = null;
+        $result = null; 
         // Execute ping
-        $txt = exec("ping -c " . $max_runs . " " . $this->server['ip'] . " 2>&1", $output);
+        $pingCommand = 'ping6';
+        $serverIp = $this->server['ip'];
+        if (filter_var($serverIp,FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false){
+            $pingCommand = 'ping';
+        }        
+        $txt = exec($pingCommand . " -c " . $max_runs . " " . $serverIp . " 2>&1", $output);
         // Non-greedy match on filler
         $re1 = '.*?';
         // Uninteresting: float
@@ -192,7 +197,9 @@ class StatusUpdater
         if (preg_match_all("/" . $re1 . $re2 . $re3 . $re4 . "/is", $txt, $matches)) {
             $result = $matches[1][0];
         }
-
+        if (substr($output[0],0,4) == 'PING' && strpos($output[count($output)-2],'packets transmitted')){
+            $result = 0;     
+        }        
         if (!is_null($result)) {
             $this->header = $output[0];
             $status = true;

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -232,7 +232,11 @@ class StatusUpdater
         // save response time
         $starttime = microtime(true);
 
-        $fp = @fsockopen($this->server['ip'], $this->server['port'], $errno, $this->error, $timeout);
+        $serverIp = $this->server['ip'];
+        if (filter_var($serverIp,FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false){
+            $serverIp = "[$serverIp]";
+        }
+        $fp = @fsockopen($serverIp, $this->server['port'], $errno, $this->error, $timeout);
 
         $status = ($fp === false) ? false : true;
         $this->rtime = (microtime(true) - $starttime);


### PR DESCRIPTION
I have tested this patch and it works for me. 
For IPv6, the last line of output is lost, then I set $result to 0 in SatatusUpdater::updatePing (phpservermon/src/psm/Util/Server/Updater/StatusUpdater.php).
An improvement can be use REGEX instead of substr() and strpos().