### PR TITLE
cron update over the web via secret key

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -6,3 +6,4 @@ define('PSM_DB_NAME', 'db_name');
 define('PSM_DB_HOST', 'localhost');
 define('PSM_DB_PORT', '3306'); //3306 is the default port for MySQL. If no specfic port is used, leave it empty.
 define('PSM_BASE_URL', '');
+define('PSM_WEBCRON_KEY', '');

--- a/cron/status.cron.php
+++ b/cron/status.cron.php
@@ -44,7 +44,10 @@ namespace {
         $data = @unserialize(PSM_CRON_ALLOW);
         $allow = $data === false ? PSM_CRON_ALLOW : $data;
 
-        if (!in_array($_SERVER['REMOTE_ADDR'], $allow) && !in_array($_SERVER["HTTP_X_FORWARDED_FOR"], $allow)) {
+        if (!in_array($_SERVER['REMOTE_ADDR'], $allow) && !in_array($_SERVER["HTTP_X_FORWARDED_FOR"], $allow)
+          && ! (array_key_exists ("webcron_key", $_GET) &&
+             $_GET["webcron_key"]==PSM_WEBCRON_KEY && (PSM_WEBCRON_KEY != ""))
+        ) {
             header('HTTP/1.0 403 Forbidden');
             die('
         <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html>

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -154,9 +154,6 @@ In config.php add following line::
 
 After that, you can hit the url http(s)://"yourmonitor.com"/cron/status.cron.php?webcron_key=YOURKEY .
 
-
-
-
 Troubleshooting
 +++++++++++++++
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -146,6 +146,16 @@ In config.php add following line::
 
 After that, you can hit the url http(s)://"yourmonitor.com"/cron/status.cron.php over the web from your allowed IP.
 
+Alternatively, define a secret key to allow the update over the web:
+
+In config.php add following line::
+
+     define('PSM_WEBCRON_KEY', 'YOURKEY');
+
+After that, you can hit the url http(s)://"yourmonitor.com"/cron/status.cron.php?webcron_key=YOURKEY .
+
+
+
 
 Troubleshooting
 +++++++++++++++


### PR DESCRIPTION
Hallo

My monitor is hosted by  a large hoster.
I cannot set up cronjobs there.
At home where I can set cronjobs, I am behind a dynamic IP.
That's why defining an IP is difficult

I therefore invented a mechanism with a shared secret key:

- a new configuration parameter `PSM_WEBCRON_KEY`,
- a new URL parameter to `status.cron.php` to pass the secret key to the monitor.

Please add this to the official code (or something similar :-) )

Thanks
