### PR TITLE
Update Requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Requirements
 * PHP cURL package
 * PHP PDO mysql driver
 * PHP-XML
+* PHP-JSON
 
 
 Install


### PR DESCRIPTION
Stock CentOS 8 + Apache + PHP7, php-json is not installed by default. Installer shows a blank page without this. Add php-json to the requirements list.