### PR TITLE
Update Requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Requirements
 * PHP cURL package
 * PHP PDO mysql driver
 * PHP-XML
+* PHP-JSON
 
 
 Install


### PR DESCRIPTION
Added "PHP-JSON", on a fresh CentOS 8 + PHP 7.2.11, php-json is needed for Telegram to work properly. This is not caught by the installer.