### PR TITLE
Adjust required php extensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,10 +79,19 @@ Requirements
 * MySQL database
 * For PHP5: 5.6.0+
 * For PHP7: 7.0.8+
-* PHP cURL package
-* PHP PDO mysql driver
-* PHP-XML
+* PHP Extensions (modules)
 
+  * ext-curl
+  * ext-ctype
+  * ext-filter
+  * ext-hash
+  * ext-json
+  * ext-libxml
+  * ext-openssl
+  * ext-pdo
+  * ext-pcre
+  * ext-sockets
+  * ext-xml
 
 Install
 -------


### PR DESCRIPTION
af5334a0 introduced the following requirements:
- ext-hash
- ext-json
- ext-libxml
- ext-openssl
- ext-pcre
- ext-sockets

Maybe also the functionality that needs the extension could be
mentioned, so someone that does not need jabber, could install with
`--ignore-platform-reqs` when not having these extensions available.