### PR TITLE
Re-adding support PHP 5.5.9/7.0.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requirements
 
 * Web server
 * MySQL database
-* For PHP5: 5.6.0+
+* For PHP5: 5.5.9+
 * For PHP7: 7.0.8+
 * PHP cURL package
 * PHP PDO mysql driver

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -5,7 +5,7 @@ Requirements
 
 * Web server
 * MySQL database
-* For PHP5: 5.6.0+
+* For PHP5: 5.5.9+
 * For PHP7: 7.0.8+
 * PHP cURL package
 * PHP PDO mysql driver

--- a/src/psm/Module/Install/Controller/InstallController.php
+++ b/src/psm/Module/Install/Controller/InstallController.php
@@ -75,11 +75,11 @@ class InstallController extends AbstractController
 
         $phpv = phpversion();
         if (
-            version_compare($phpv, '5.6.0', '<') ||
+            version_compare($phpv, '5.5.9', '<') ||
             (version_compare($phpv, '7.0.8', '<') && version_compare($phpv, '7.0.0', '>='))
         ) {
             $errors++;
-            $this->addMessage('PHP 5.6.0+ or 7.0.8+ is required to run PHP Server Monitor. You\'re using ' .
+            $this->addMessage('PHP 5.5.9+ or 7.0.8+ is required to run PHP Server Monitor. You\'re using ' .
                 $phpv . '.', 'error');
         } else {
             $this->addMessage('PHP version: ' . $phpv, 'success');

--- a/src/psm/Module/User/UserEvents.php
+++ b/src/psm/Module/User/UserEvents.php
@@ -35,15 +35,15 @@ final class UserEvents
     /**
      * @var string
      */
-    public const USER_ADD = 'user.add';
+    const USER_ADD = 'user.add';
 
     /**
      * @var string
      */
-    public const USER_EDIT = 'user.edit';
+    const USER_EDIT = 'user.edit';
 
     /**
      * @var string
      */
-    public const USER_DELETE = 'user.delete';
+    const USER_DELETE = 'user.delete';
 }

--- a/src/psm/Txtmsg/CMBulkSMS.php
+++ b/src/psm/Txtmsg/CMBulkSMS.php
@@ -67,10 +67,10 @@ class CMBulkSMS extends Core
     protected $messageBody;
 
     /** @var string JSON Gateway API URL */
-    public const GATEWAY_URL_JSON = "https://gw.cmtelecom.com/v1.0/message";
+    const GATEWAY_URL_JSON = "https://gw.cmtelecom.com/v1.0/message";
 
     /** @var string XML Gateway API URL */
-    public const GATEWAY_URL_XML = "https://sgw01.cm.nl/gateway.ashx";
+    const GATEWAY_URL_XML = "https://sgw01.cm.nl/gateway.ashx";
 
     /**
      * Build the message and send cURL request to the sms gateway

--- a/src/psm/Util/Module/Modal.php
+++ b/src/psm/Util/Module/Modal.php
@@ -32,9 +32,9 @@ namespace psm\Util\Module;
 class Modal implements ModalInterface
 {
 
-    public const MODAL_TYPE_OK = 0;
-    public const MODAL_TYPE_OKCANCEL = 1;
-    public const MODAL_TYPE_DANGER = 2;
+    const MODAL_TYPE_OK = 0;
+    const MODAL_TYPE_OKCANCEL = 1;
+    const MODAL_TYPE_DANGER = 2;
 
     /**
      * prefix used for modal dialog box elements


### PR DESCRIPTION
as per #908:
"public const" visibility suppport was only added by php 5.6/php7.1 but is default behaviour of a const declaration so not necessary. For compatibiliy one can simply omit "public" in const declaration to reenable php 5.5.9 and 7.0.x compatibility