### PR TITLE
Show recent status logs on server details page

### DIFF
--- a/src/templates/default/module/server/server/view.tpl.html
+++ b/src/templates/default/module/server/server/view.tpl.html
@@ -354,6 +354,35 @@
 	<div class="row">
 		{{ html_history|raw }}
 	</div>
+	{% if log_entries %}
+	<div class="row mt-4">
+		<div class="card col-md-12 pl-0 pr-0">
+			<div class="card-header">
+				{{ label_log_title }}
+			</div>
+			<div class="card-body d-flex align-items-center justify-content-center">
+				<div class="table-responsive">
+					<table class="table table-striped table-hover">
+						<thead>
+						<tr>
+							<th scope="col" style="width: 15%;">{{ label_date }}</th>
+							<th scope="col">{{ label_message }}</th>
+						</tr>
+						</thead>
+						<tbody>
+						{% for entry in log_entries %}
+						<tr>
+							<td><time>{{ entry.datetime_format }}</time></td>
+							<td class="full">{{ entry.message|raw }}</td>
+						</tr>
+						{% endfor %}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	{% endif %}
 
 	<div class="modal fade" id="modal_last_output" tabindex="-1" role="dialog" aria-labelledby="modal_last_output_label" aria-hidden="true">
 		<div class="modal-dialog" style="width:75%;max-width: 100%" role="document">


### PR DESCRIPTION
Small QoL change - show recent status logs on server details page.

Screenshot:
![image](https://user-images.githubusercontent.com/13499892/82198393-8a700880-98fc-11ea-9b39-5bab1fc3e9fa.png)
