### PR TITLE
Fix Plivo SMS encoding

### DIFF
--- a/src/psm/Txtmsg/Plivo.php
+++ b/src/psm/Txtmsg/Plivo.php
@@ -74,7 +74,7 @@ class Plivo extends Core
                 array(
                     "src" => $this->originator,
                     "dst" => $recipients,
-                    "text" => urlencode($message)
+                    "text" => $message
                 )
             ),
             CURLOPT_HTTPHEADER => array(


### PR DESCRIPTION
Fix for Plivo SMS encoding. 
Message string was not encoding correctly resulting in '%20's appearing instead of spaces, etc