### PR TITLE
Add error message for missing/invalid header

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -331,23 +331,20 @@ class StatusUpdater
                             list ($key, $value) = explode(': ', $line);
                             // Header found (case-insensitive)
                             if (strcasecmp($key, $this->server['header_name']) == 0) {
-                                // The value doesn't match what we needed
-                                if (!preg_match("/{$this->server['header_value']}/i", $value)) {
-                                    $result = false;
-                                } else {
+                                // The value matches what we need, everything is fine
+                                if (preg_match("/{$this->server['header_value']}/i", $value)) {
                                     $header_flag = true;
-                                    break; // No need to go further
+                                    break; // The correct header is found, we leave the loop
                                 }
                             }
                         }
                     }
 
                     if (!$header_flag) {
-                        // Header was not present
-                        $result = false;
-                        $this->error =
-                            'HEADER ERROR : Header "' . $this->server['header_name'] .
+                        // Header was not present, set error message and $result variable
+                        $this->error = 'HEADER ERROR : Header "' . $this->server['header_name'] .
                             '" not found or does not match "/' . $this->server['header_value'] . '/i".';
+                        $result = false;
                     }
                 }
             }

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -345,6 +345,9 @@ class StatusUpdater
                     if (!$header_flag) {
                         // Header was not present
                         $result = false;
+                        $this->error =
+                            'HEADER ERROR : Header "' . $this->server['header_name'] .
+                            '" not found or does not match "/' . $this->server['header_value'] . '/i".';
                     }
                 }
             }
@@ -447,7 +450,7 @@ class StatusUpdater
         socket_send($socket, $package, strLen($package), 0);
         // socket_read returns a string or false
         $status = socket_read($socket, 255) !== false ? true : false;
-        
+
         if ($status) {
             $this->header = "Success.";
         } else {


### PR DESCRIPTION
If the header was missing or invalid the error message was not changed. I added a new error message for this case.