### PR TITLE
Fix: 'Cookies must be enabled in your browser!' message on some pages

### DIFF
--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -419,6 +419,7 @@ namespace {
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_CERTINFO, 1);
+        curl_setopt($ch, CURLOPT_COOKIEFILE, '');
 
         if (!empty($request_method)) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request_method);


### PR DESCRIPTION
Some pages response with a 'Cookies must be enabled in your browser!' message.
This additional option fixes this.