### PR TITLE
Support for mysql unix socket

### DIFF
--- a/src/psm/Service/Database.php
+++ b/src/psm/Service/Database.php
@@ -533,16 +533,29 @@ class Database
      */
     protected function connect()
     {
+        $isHostUnixSocket = strpos($this->db_host, ':') === 0;
+
         // Initizale connection
         try {
-            $this->pdo = new \PDO(
-                'mysql:host=' . $this->db_host .
-                    ';port=' . $this->db_port .
-                    ';dbname=' . $this->db_name .
-                    ';charset=utf8',
-                $this->db_user,
-                $this->db_pass
-            );
+            if ($isHostUnixSocket) {
+                $this->pdo = new \PDO(
+                    'mysql:unix_socket=' . ltrim($this->db_host, ':') .
+                        ';dbname=' . $this->db_name .
+                        ';charset=utf8',
+                    $this->db_user,
+                    $this->db_pass
+                );
+            } else {
+                $this->pdo = new \PDO(
+                    'mysql:host=' . $this->db_host .
+                        ';port=' . $this->db_port .
+                        ';dbname=' . $this->db_name .
+                        ';charset=utf8',
+                    $this->db_user,
+                    $this->db_pass
+                );
+            }
+
             $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->status = true;
         } catch (\PDOException $e) {


### PR DESCRIPTION
This will add support for connecting with a unix socket path to the mysql database.
Users will need to set their `PSM_DB_HOST` the a unix socket path starting with an ":" symbol, like so
`:/home/xxxxxx/var/run/mysql.sock`

I stole this way idea of using the database host field to store the unix socket path from Nextcloud.
They do the same.

Related: https://github.com/phpservermon/phpservermon/issues/1118

NOTE: I haven't the tools nor the time to test this 100% in the entire application.

For instance, I configured my local mysqld to use regular host/port first, and I did setup PhpServerMonitor using the `install.php`. Then, when all was working, I edited manually the config to change `PSM_DB_HOST` to my unix socket path.
I cannot garantee that the `install.php` and graphical setup can support putting a unix socket path into the host field.
Didn't check the php, didn't check the front.