### PR TITLE
Fixed SMTPAutoTLS Default

### DIFF
--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -603,7 +603,9 @@ namespace {
             $phpmailer->Host = psm_get_conf('email_smtp_host');
             $phpmailer->Port = (int)psm_get_conf('email_smtp_port');
             $phpmailer->SMTPSecure = psm_get_conf('email_smtp_security');
-
+            if (psm_get_conf('email_smtp_security') == ''){
+                $phpmailer->SMTPAutoTLS = false;
+            }
             $smtp_user = psm_get_conf('email_smtp_username');
             $smtp_pass = psm_password_decrypt(
                 psm_get_conf('password_encrypt_key'),


### PR DESCRIPTION
PHPMailer will always try to connect to an SMTP server via TLS by default regardless of the SMTPSecure Setting. Added a check to set SMTPAutoTLS to false when email_smtp_security is empty.