### PR TITLE
Update FreeMobileSMS.php - Fix encoding bug

### DIFF
--- a/src/psm/Txtmsg/FreeMobileSMS.php
+++ b/src/psm/Txtmsg/FreeMobileSMS.php
@@ -58,7 +58,7 @@ class FreeMobileSMS extends Core
             array(
                     "user" => $this->username,
                     "pass" => $this->password,
-                    "msg" => urlencode($message),
+                    "msg" => rawurlencode($message),
                 )
         ));
 


### PR DESCRIPTION
Fix the URL encoding by changing urlencode to rawurlencode, since the former uses + instead of %20 to encode an URL and is meant for form submissions. Rawurlencode is meant for creating URLs, and should fix bug #1120