### PR TITLE
Add import/export functionality (JSON)

### DIFF
--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -50,6 +50,8 @@ $sm_lang = array(
         'no' => 'No',
         'insert' => 'Insert',
         'add_new' => 'Add new',
+        'export_config' => 'Export Configuration',
+        'import_config' => 'Import Configuration',
         'update_available' => 'A new version ({version}) is available. Click <a href="https://github.com/phpservermon/phpservermon/releases/latest" target="_blank" rel="noopener">here</a> to download the update.',
         'back_to_top' => 'Back to top',
         'go_back' => 'Go back',

--- a/src/templates/default/main/macros.tpl.html
+++ b/src/templates/default/main/macros.tpl.html
@@ -33,6 +33,22 @@
     </div>
 {% endmacro input_select %}
 
+
+{% macro input_upload(id, name, label,  help, help_label) %}
+<div class="form-group">
+        <label for="{{ id }}">{{ label }}</label> <br \>
+        <input type="file" id="{{ id }}" name="{{ name }}"
+            {% if help %}aria-describedby="{{ help }}"{% endif %}>
+        
+        {% if help %}
+            <small id="{{ help }}" class="form-text text-muted">{{
+            help_label|striptags('<a>,<b>,<br>')|raw }}</small>
+        {% endif %}
+    
+</div>
+{% endmacro input_upload %}
+
+
 {% macro input_select_multiple(id, name, label, placeholder, options, select_message) %}
     <div class="form-group">
         <label for="{{ id }}">{{ label }}</label>

--- a/src/templates/default/module/server/server/import.tpl.html
+++ b/src/templates/default/module/server/server/import.tpl.html
@@ -3,6 +3,9 @@
  autocomplete="off" enctype="multipart/form-data">
 	<fieldset>
 		<legend>{{ titlemode }}</legend>
+		{% if error_message != "" %}
+		<div class="card text-white bg-danger px-3 pt-3 pb-2 mb-4"><h3>Error: {{ error_message }}</h3></div>
+		{% endif %}
 		<div class="col">
 			<!-- Label -->
 			{{ macro.input_upload("import_upload", "import_upload", "Upload Configuration", null, null) }}

--- a/src/templates/default/module/server/server/import.tpl.html
+++ b/src/templates/default/module/server/server/import.tpl.html
@@ -1,0 +1,15 @@
+{% import 'main/macros.tpl.html' as macro %}
+<form name="importpost" action="{{ url_save|raw }}" class="col-md-6 pl-0 pr-0" id="importpost" method="post"
+ autocomplete="off" enctype="multipart/form-data">
+	<fieldset>
+		<legend>{{ titlemode }}</legend>
+		<div class="col">
+			<!-- Label -->
+			{{ macro.input_upload("import_upload", "import_upload", "Upload Configuration", null, null) }}
+
+			<!-- Submit -->
+			<legend>{{ label_upload }}</legend>
+			{{ macro.button_save(null, label_upload) }}
+			<a class="btn" href="{{ url_go_back|raw }}">Go Back</a>
+	{{ macro.input_csrf() }}
+</form>


### PR DESCRIPTION
This PR is in its early stages, but I wanted to see that I'm on the right track with this. There's some fine-tuning to do, but for now this works like the following: 

- On the server page, there's an Import and Export button
- The Export button takes the server list and exports it to a json-file
- The import button takes you to a file upload site, where you can import a json-file iwith the same format.

Both the export and import functionality use slightly modified existing functions for export/import, for example the ExecuteSave function in the server model is used to insert the servers into the database. 
There were some slight modifications made to accept a list with invalid IDs (for example an export from another instance), and the $_POST-hack is a bit ugly, but it works at the moment. 

The principle is you should be able to export and then import without any changes happening, but if you change stuff in the JSON it changes in the system. In addition, you should be able to export from one system and into another. 

I'd appreciate some feedback, I know this has been requested over and over at this point... Clone the scheibling/phpservermon:add-serverimport-from-json-branch to test it out in its current form.

Closes #1081
Closes #1102
Closes #874
Closes #250

To Do: 

- [ ] Add language links to all of the texts/buttons
- [ ] Translate into other languages
- [ ] Find a better solution than the $_POST-hijacking
- [ ] Add section to readme for usage instructions? 
- [ ] Add instructions on import-page?

Cheers! 
/Lars