### PR TITLE
Remove onclick from non-link table cells

### DIFF
--- a/src/templates/default/module/server/status/index.tpl.html
+++ b/src/templates/default/module/server/status/index.tpl.html
@@ -65,7 +65,7 @@
 				</thead>
 				<tbody>
 					{% for server in servers_offline %}
-						<tr class="bg-danger text-white" onclick="window.location.href='{{ server.url_view|raw }}'">
+						<tr class="bg-danger text-white">
 							<th class="full"><a href="{{ server.url_view|raw }}" class="text-white">{{ server.label }}<span class="sr-only"> ({{ label_offline }})</span></a></th>
 							<td>{{ server.last_online_nice }}</td>
 							<td>{{ server.last_checked_nice }}</td>
@@ -73,7 +73,7 @@
 						</tr>
 					{% endfor %}
 					{% for server in servers_warning %}
-						<tr class="bg-warning text-white" onclick="window.location.href='{{ server.url_view|raw }}'">
+						<tr class="bg-warning text-white">
 							<th class="full"><a href="{{ server.url_view|raw }}" class="text-white">{{ server.label }}<span class="sr-only"> ({{ label_warning }})</span></a></th>
 							<td>{{ server.last_online_nice }}</td>
 							<td>{{ server.last_checked_nice }}</td>
@@ -93,7 +93,7 @@
 				</thead>
 				<tbody>
 					{% for server in servers_online %}
-						<tr class="bg-success text-white" onclick="window.location.href='{{ server.url_view|raw }}'">
+						<tr class="bg-success text-white">
 							<th class="full"><a href="{{ server.url_view|raw }}" class="text-white">{{ server.label }}<span class="sr-only"> ({{ label_online }})</span></a></th>
 							<td>{{ server.last_online_nice }}</td>
 							<td>{{ server.last_offline_nice }} {{ server.last_offline_duration_nice }}</td>


### PR DESCRIPTION
This removes the onclick attribute from the table cells on the index page.  The first cell of each row already has an "a" link which takes the user to the same place and is more intuitive since hovering over that "a" link changes the cursor to a "pointer."  The other cells still showed a "text" cursor which implied the elements were not clickable, though they were.  Removing the onclick from those other cells also allows the user to select their text for copy/paste purposes without getting redirected to another page unexpectedly.