### PR TITLE
Feature: Add a custom HEADER field to servers requests

### DIFF
--- a/src/includes/functions.inc.php
+++ b/src/includes/functions.inc.php
@@ -390,6 +390,7 @@ namespace {
      * @param string|bool $website_password Password website
      * @param string|null $request_method Request method like GET, POST etc.
      * @param string|null $post_field POST data
+     * @param string|null $custom_header HEADER data
      * @return array cURL result
      */
     function psm_curl_get(
@@ -401,7 +402,8 @@ namespace {
         $website_username = false,
         $website_password = false,
         $request_method = null,
-        $post_field = null
+        $post_field = null,
+        $custom_header = null
     ) {
         ($timeout === null || $timeout > 0) ? PSM_CURL_TIMEOUT : intval($timeout);
 
@@ -427,6 +429,10 @@ namespace {
 
         if (!empty($post_field)) {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $post_field);
+        }
+
+        if (!empty($custom_header)){
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array($custom_header));
         }
 
         if (

--- a/src/lang/en_US.lang.php
+++ b/src/lang/en_US.lang.php
@@ -283,6 +283,8 @@ $sm_lang = array(
         'error_server_type_invalid' => 'The selected server type is invalid.',
         'error_server_warning_threshold_invalid' => 'The warning threshold must be a valid integer greater than 0.',
         'error_server_ssl_cert_expiry_days' => 'The remaining days for SSL certificate validity must be a valid integer greater than or equal to 0.',
+        'custom_header' => 'Custom header',
+        'custom_header_description' => 'Allows to add a custom header to the request.',
     ),
     'config' => array(
         'general' => 'General',

--- a/src/lang/fr_FR.lang.php
+++ b/src/lang/fr_FR.lang.php
@@ -272,6 +272,8 @@ $sm_lang = array(
         'error_server_ip_bad_website' => 'L\'URL du site web n\'est pas valide.',
         'error_server_type_invalid' => 'Le type de service sélectionné n\'est pas valide.',
         'error_server_warning_threshold_invalid' => 'Le seuil d\'alerte doit être un nombre entier supérieur à 0.',
+        'custom_header' => 'Header personnalisé',
+        'custom_header_description' => 'Permet d\'ajouter une directive HEADER personnalisée à la requête',
     ),
     'config' => array(
         'general' => 'Général',

--- a/src/psm/Module/Server/Controller/AbstractServerController.php
+++ b/src/psm/Module/Server/Controller/AbstractServerController.php
@@ -95,7 +95,8 @@ abstract class AbstractServerController extends AbstractController
 					`s`.`website_password`,
 					`s`.`last_error`,
 					`s`.`last_error_output`,
-					`s`.`last_output`
+					`s`.`last_output`,
+                    `s`.`custom_header`
 				FROM `" . PSM_DB_PREFIX . "servers` AS `s`
 				{$sql_join}
 				{$sql_where}

--- a/src/psm/Module/Server/Controller/ServerController.php
+++ b/src/psm/Module/Server/Controller/ServerController.php
@@ -246,6 +246,7 @@ class ServerController extends AbstractServerController
                 'edit_pushover_selected' => $edit_server['pushover'],
                 'edit_telegram_selected' => $edit_server['telegram'],
                 'edit_jabber_selected' => $edit_server['jabber'],
+                'edit_custom_header' => $edit_server['custom_header'],
             ));
         }
 
@@ -322,6 +323,7 @@ class ServerController extends AbstractServerController
             'webhook' => in_array($_POST['webhook'], array('yes', 'no')) ? $_POST['webhook'] : 'no',
             'telegram' => in_array($_POST['telegram'], array('yes', 'no')) ? $_POST['telegram'] : 'no',
             'jabber' => in_array($_POST['jabber'], array('yes', 'no')) ? $_POST['jabber'] : 'no',
+            'custom_header' => empty(psm_POST('custom_header')) ? null : psm_POST('custom_header'),
         );
         // make sure websites start with http://
         if (
@@ -636,6 +638,8 @@ class ServerController extends AbstractServerController
             'label_log_no_logs' => psm_get_lang('log', 'no_logs'),
             'label_date' => psm_get_lang('system', 'date'),
             'label_message' => psm_get_lang('system', 'message'),
+            'label_custom_header' => psm_get_lang('servers', 'custom_header'),
+            'label_custom_header_description' => psm_get_lang('servers', 'custom_header_description'),
         );
     }
 

--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -747,6 +747,8 @@ class Installer
             CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;";
         $queries[] = "ALTER TABLE `" . PSM_DB_PREFIX . "servers` 
             ADD `webhook` ENUM( 'yes','no' ) NOT NULL DEFAULT 'yes' AFTER `telegram`;";
+        $queries[] = "ALTER TABLE `" . PSM_DB_PREFIX . "servers` 
+            ADD `custom_header` TEXT NULL DEFAULT NULL AFTER `last_output`;";
         $queries[] = "INSERT INTO `" . PSM_DB_PREFIX . "config` (`key`, `value`) VALUE
                     ('discord_status', '0'),
                     ('log_discord', '1'),

--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -293,6 +293,7 @@ class Installer
                 `last_error` varchar(255) DEFAULT NULL,
                 `last_error_output` TEXT,
                 `last_output` TEXT,
+                `custom_header` TEXT NULL DEFAULT NULL,
                 PRIMARY KEY  (`server_id`)
             ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'servers_uptime' => "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "servers_uptime` (

--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -100,7 +100,7 @@ class StatusUpdater
             'allow_http_status', 'redirect_check', 'header_name',
             'header_value', 'status', 'active', 'warning_threshold',
             'warning_threshold_counter', 'ssl_cert_expiry_days', 'ssl_cert_expired_time', 'timeout', 'website_username',
-            'website_password', 'last_offline'
+            'website_password', 'last_offline', 'custom_header'
         ));
         if (empty($this->server)) {
             return false;
@@ -248,7 +248,8 @@ class StatusUpdater
             psm_password_decrypt($this->server['server_id'] .
                 psm_get_conf('password_encrypt_key'), $this->server['website_password']),
             $this->server['request_method'],
-            $this->server['post_field']
+            $this->server['post_field'],
+            $this->server['custom_header']
         );
         $this->header = $curl_result['exec'];
         $this->curl_info = $curl_result['info'];

--- a/src/templates/default/module/server/server/update.tpl.html
+++ b/src/templates/default/module/server/server/update.tpl.html
@@ -120,6 +120,12 @@
 			{{ macro.input_field("number", "timeout", null, "timeout", label_timeout, edit_value_timeout, default_value_timeout, "10", 'timeout_help', label_timeout_description) }}
 		</div>
 	</fieldset>
+	<fieldset>
+		<legend>{{ label_custom_header }} ({{ label_optional }})</legend>
+		<div class="col">
+			{{ macro.input_field("text", "custom_header", null, "custom_header", label_custom_header, edit_custom_header, "Cookie:...", null, 'custom_header_help', label_custom_header_description) }}
+		</div>
+	</fieldset>
 	<fieldset class="types typeWebsite">
 		<legend>{{ label_authentication_settings }} ({{ label_optional }})</legend>
 		<div class="col">


### PR DESCRIPTION
This PR adds a new field in server edit screen.
This fields allows to add a custom HEADER to the server requests.
For example it can be a Cookie header or a JWT Authorization Bearer.
The custom header is added in the `psm_curl_get` function with the `CURLOPT_HTTPHEADER` option.