### PR TITLE
Add IP whitelist turn off option

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -7,4 +7,6 @@ define('PSM_DB_HOST', 'localhost');
 define('PSM_DB_PORT', '3306'); //3306 is the default port for MySQL. If no specfic port is used, leave it empty.
 define('PSM_BASE_URL', '');
 define('PSM_WEBCRON_KEY', '');
+define('PSM_WEBCRON_ENABLE_IP_WHITELIST', 'true'); // Enable IP whitelisting for calling webcron
 define('PSM_PUBLIC', false);
+

--- a/cron/status.cron.php
+++ b/cron/status.cron.php
@@ -44,10 +44,16 @@ namespace {
         $data = @unserialize(PSM_CRON_ALLOW);
         $allow = $data === false ? PSM_CRON_ALLOW : $data;
 
-        if (!in_array($_SERVER['REMOTE_ADDR'], $allow) && !in_array($_SERVER["HTTP_X_FORWARDED_FOR"], $allow)
-          && ! (array_key_exists ("webcron_key", $_GET) &&
-             $_GET["webcron_key"]==PSM_WEBCRON_KEY && (PSM_WEBCRON_KEY != ""))
-        ) {
+        $ipWhitelistCheckPassed = in_array($_SERVER['REMOTE_ADDR'], $allow)
+            && in_array($_SERVER["HTTP_X_FORWARDED_FOR"], $allow)
+            && PSM_WEBCRON_ENABLE_IP_WHITELIST;
+
+        $webCronKeyCheckPassed =
+            array_key_exists ("webcron_key", $_GET)
+            && $_GET["webcron_key"] == PSM_WEBCRON_KEY
+            && (PSM_WEBCRON_KEY != "");
+
+        if (!$ipWhitelistCheckPassed && !$webCronKeyCheckPassed) {
             header('HTTP/1.0 403 Forbidden');
             die('
         <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html>

--- a/dev/vagrant-config.php
+++ b/dev/vagrant-config.php
@@ -7,4 +7,5 @@ define('PSM_DB_HOST', 'localhost');
 define('PSM_DB_PORT', '3306'); //3306 is the default port for MySQL. If no specfic port is used, leave it empty.
 define('PSM_BASE_URL', '');
 define('PSM_WEBCRON_KEY', '');
+define('PSM_WEBCRON_ENABLE_IP_WHITELIST', 'true');
 define('PSM_PUBLIC', false);


### PR DESCRIPTION
Hi I added option that is necessary in my deployment case. The webhosting provider I am using is calling the webcron from different machines in his infrastructure so i think it is helpful to have option to disable the IP whitelisting check.

Or at least anyone else configuring this system in the future will see (or at least have chance to see) that something like IP whitelisting for webcron is enabled by default in the configuration.