### PR TITLE
Remove explicit MyISAM engine dependency from table create statements

### DIFF
--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -240,7 +240,7 @@ class Installer
                 `user_id` INT( 11 ) UNSIGNED NOT NULL ,
                 `server_id` INT( 11 ) UNSIGNED NOT NULL ,
                 PRIMARY KEY ( `user_id` , `server_id` )
-            ) ENGINE = MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'log' => "CREATE TABLE `" . PSM_DB_PREFIX . "log` (
                 `log_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                 `server_id` int(11) unsigned NOT NULL,

--- a/src/psm/Util/Install/Installer.php
+++ b/src/psm/Util/Install/Installer.php
@@ -207,7 +207,7 @@ class Installer
                 `key` varchar(255) NOT NULL,
                 `value` varchar(255) NOT NULL,
                 PRIMARY KEY (`key`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'users' => "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "users` (
                 `user_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                 `user_name` varchar(64) NOT NULL COMMENT 'user''s name, unique',
@@ -228,14 +228,14 @@ class Installer
                 `email` varchar(255) NOT NULL,
                 PRIMARY KEY (`user_id`),
                 UNIQUE KEY `unique_username` (`user_name`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX .
                 'users_preferences' => "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "users_preferences` (
                 `user_id` int(11) unsigned NOT NULL,
                 `key` varchar(255) NOT NULL,
                 `value` varchar(255) NOT NULL,
                 PRIMARY KEY (`user_id`, `key`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'users_servers' => "CREATE TABLE `" . PSM_DB_PREFIX . "users_servers` (
                 `user_id` INT( 11 ) UNSIGNED NOT NULL ,
                 `server_id` INT( 11 ) UNSIGNED NOT NULL ,
@@ -248,12 +248,12 @@ class Installer
                 `message` TEXT NOT NULL,
                 `datetime` timestamp NOT NULL default CURRENT_TIMESTAMP,
                 PRIMARY KEY  (`log_id`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'log_users' => "CREATE TABLE `" . PSM_DB_PREFIX . "log_users` (
                 `log_id`  int(11) UNSIGNED NOT NULL ,
                 `user_id`  int(11) UNSIGNED NOT NULL ,
                 PRIMARY KEY (`log_id`, `user_id`)
-            ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;",
+            )  DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'servers' => "CREATE TABLE `" . PSM_DB_PREFIX . "servers` (
                 `server_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                 `ip` varchar(500) NOT NULL,
@@ -294,7 +294,7 @@ class Installer
                 `last_error_output` TEXT,
                 `last_output` TEXT,
                 PRIMARY KEY  (`server_id`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'servers_uptime' => "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "servers_uptime` (
                 `servers_uptime_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                 `server_id` int(11) unsigned NOT NULL,
@@ -303,7 +303,7 @@ class Installer
                 `latency` float(9,7) DEFAULT NULL,
                 PRIMARY KEY (`servers_uptime_id`),
                 KEY `server_id` (`server_id`)
-            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            ) DEFAULT CHARSET=utf8;",
             PSM_DB_PREFIX . 'servers_history' => "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "servers_history` (
                 `servers_history_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                 `server_id` int(11) unsigned NOT NULL,
@@ -315,7 +315,7 @@ class Installer
                 `checks_failed` int(11) unsigned NOT NULL,
                 PRIMARY KEY (`servers_history_id`),
                 UNIQUE KEY `server_id_date` (`server_id`,`date`)
-            ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;",
+            )  DEFAULT CHARSET=utf8;",
         );
 
         foreach ($tables as $name => $sql) {
@@ -468,7 +468,7 @@ class Installer
                         `latency` float(9,7) DEFAULT NULL,
                         PRIMARY KEY (`servers_uptime_id`),
                         KEY `server_id` (`server_id`)
-                      ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;";
+                      )  DEFAULT CHARSET=utf8;";
 
         $queries[] = "CREATE TABLE IF NOT EXISTS `" . PSM_DB_PREFIX . "servers_history` (
                 `servers_history_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -481,7 +481,7 @@ class Installer
                 `checks_failed` int(11) unsigned NOT NULL,
                           PRIMARY KEY (`servers_history_id`),
                           UNIQUE KEY `server_id_date` (`server_id`,`date`)
-                        ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;";
+                        )  DEFAULT CHARSET=utf8;";
 
         $queries[] = "CREATE TABLE `" . PSM_DB_PREFIX . "users_servers` (
                         `user_id` INT( 11 ) UNSIGNED NOT NULL ,
@@ -543,7 +543,7 @@ class Installer
                         `key` varchar(255) NOT NULL,
                         `value` varchar(255) NOT NULL,
                         PRIMARY KEY (`user_id`, `key`)
-                      ) ENGINE=MyISAM DEFAULT CHARSET=utf8;";
+                      ) DEFAULT CHARSET=utf8;";
 
         $this->execSQL($queries);
     }
@@ -572,7 +572,7 @@ class Installer
                         `log_id`  int(11) UNSIGNED NOT NULL ,
                         `user_id`  int(11) UNSIGNED NOT NULL ,
                         PRIMARY KEY (`log_id`, `user_id`)
-                      ) ENGINE=MyISAM DEFAULT CHARSET=utf8;");
+                      ) DEFAULT CHARSET=utf8;");
 
         // Migrate the data
         $logs = $this->db->select(PSM_DB_PREFIX . 'log', null, array('log_id', 'user_id'));


### PR DESCRIPTION
Usage of MyISAM is discouraged and should not be a hard requirement. 