### PR TITLE
Removed error message for security purposes

### DIFF
--- a/src/psm/Module/User/Controller/LoginController.php
+++ b/src/psm/Module/User/Controller/LoginController.php
@@ -93,7 +93,8 @@ class LoginController extends AbstractController
     {
         if (isset($_POST['user_name'])) {
             $user = $this->getUser()->getUserByUsername($_POST['user_name']);
-
+            $this->addMessage(psm_get_lang('login', 'success_password_forgot'), 'success');
+            
             if (!empty($user)) {
                 $token = $this->getUser()->generatePasswordResetToken($user->user_id);
                 // we have a token, send it along
@@ -102,11 +103,8 @@ class LoginController extends AbstractController
                     $user->email,
                     $token
                 );
-
-                $this->addMessage(psm_get_lang('login', 'success_password_forgot'), 'success');
+                
                 return $this->executeLogin();
-            } else {
-                $this->addMessage(psm_get_lang('login', 'error_user_incorrect'), 'error');
             }
         }
 


### PR DESCRIPTION
Resolves #1280.
Removes error message for password reset when a user does not exist. Now it will always show a success message.