### PR TITLE
Fix missing PSM_UPTIME_ARCHIVE definition

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -9,4 +9,5 @@ define('PSM_BASE_URL', '');
 define('PSM_WEBCRON_KEY', '');
 define('PSM_WEBCRON_ENABLE_IP_WHITELIST', 'true'); // Enable IP whitelisting for calling webcron
 define('PSM_PUBLIC', false);
+define('PSM_UPTIME_ARCHIVE', 'monthly);
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -121,6 +121,12 @@ namespace {
         define('PSM_PUBLIC_PAGE', false);
     }
 
+    // check for a uptime archive
+    // This should be defined in the config
+    if (!defined('PSM_UPTIME_ARCHIVE')) {
+        define('PSM_UPTIME_ARCHIVE', 'monthly);
+    }
+
     $lang = psm_get_conf('language', 'en_US');
     psm_load_lang($lang);
 }


### PR DESCRIPTION
Fixes an issue with PHP ^8.0 for missing PSM_UPTIME_ARCHIVE definition.

Added to config.php.sample and bootstrap.php to make it more resilient.