### PR TITLE
Fix: False "Online" status for failed pings on modern Linux systems

### DIFF
--- a/src/psm/Util/Server/Updater/StatusUpdater.php
+++ b/src/psm/Util/Server/Updater/StatusUpdater.php
@@ -175,19 +175,31 @@ class StatusUpdater
      */
     protected function updatePing($max_runs, $run = 1)
     {
-        // Settings
-        $max_runs = ($max_runs == null || $max_runs > 1) ? 1 : $max_runs;
-        $server_ip = escapeshellcmd($this->server['ip']);
+        $starttime = microtime(true);
+        $ip = $this->server['ip'];
         $os_is_windows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+        
+        if ($os_is_windows) {
+            // Windows Ping: -n 1 (1 packet), -w 2000 (2000ms timeout)
+            exec('ping -n 1 -w 2000 ' . escapeshellarg($ip), $output, $result);
+            $output_str = implode("", $output);
+            // Windows ping notoriously returns 0 on unreachable hosts. Verify with "TTL="
+            $status = ($result === 0 && stripos($output_str, 'TTL=') !== false) ? true : false;
+        } else {
+            // Linux/Unix Ping: -c 1 (1 packet), -w 2 (2s timeout), capture stderr
+            exec('ping -c 1 -w 2 ' . escapeshellarg($ip) . ' 2>&1', $output, $result);
+            // Core fix for Linux: Only trust the Return Code! (0 is success)
+            $status = ($result === 0) ? true : false;
+        }
+        
+        // Record the response time
+        $this->rtime = (microtime(true) - $starttime);
 
-        $status = $os_is_windows ?
-            $this->pingFromWindowsMachine($server_ip, $max_runs) :
-            $this->pingFromNonWindowsMachine($server_ip, $max_runs);
-
-        // check if server is available and rerun if asked.
-        if (!$status && $run < $max_runs) {
+        // If it fails and we haven't reached max retries, try again
+        if(!$status && $run < $max_runs) {
             return $this->updatePing($max_runs, $run + 1);
         }
+        
         return $status;
     }
 


### PR DESCRIPTION
## Summary

Fix incorrect ping status detection on newer Linux distributions.

PHP Server Monitor v3.5.2 determines host availability by parsing the `ping` output using Regex.  
It assumes that if the output contains the keyword `time`, the host is online.

However, newer Linux distributions (e.g. recent Debian versions) always print a line such as:

    time 1016ms

even when the result shows:

    100% packet loss

This causes unreachable hosts to be incorrectly reported as **Online (0ms)**.

---

## Root Cause

The current implementation relies on parsing terminal text output instead of checking the actual command return code.

On modern Linux systems:

- `ping` still prints total execution time even if all packets are lost.
- The return code correctly indicates failure (non‑zero).

The existing Regex logic ignores packet loss and misinterprets the output.

---

## Fix

Rewrite `updatePing()` to rely on the OS return code:

- Linux/Unix: treat return code `0` as success, non‑zero as failure.
- Windows: verify both return code and presence of `TTL=` (since Windows may return `0` even when unreachable).

This makes the detection logic:

- OS‑level reliable
- Distribution‑agnostic
- Future‑proof

---

## Result

Unreachable hosts are now correctly reported as **Offline** on modern Linux systems.

---

## Tested On

- Debian 13
- PHP Server Monitor v3.5.2